### PR TITLE
Feature/metadata model

### DIFF
--- a/schemas/generated/docs/asct-b-metadata/about.md
+++ b/schemas/generated/docs/asct-b-metadata/about.md
@@ -1,0 +1,28 @@
+
+# Slot: about
+
+
+
+
+URI: [dcat:about](http://www.w3.org/ns/dcat#about)
+
+
+## Domain and Range
+
+None &#8594;  <sub>0..1</sub> [String](types/String.md)
+
+## Parents
+
+
+## Children
+
+
+## Used by
+
+
+## Other properties
+
+|  |  |  |
+| --- | --- | --- |
+| **Mappings:** | | schema:about |
+

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -145,7 +145,7 @@ classes:
   Container:
     tree_root: true
     attributes:
-      id:
+      iri:
         range: uriorcurie
       metadata:
         range: AsctbMetadata
@@ -153,15 +153,15 @@ classes:
         range: AsctbDataset
     annotations:
       owl.template: |-
-        AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
+        AnnotationAssertion( dct:title {{iri}} "{{metadata.title}}" )
+        AnnotationAssertion( dct:description {{iri}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
-        AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
+        AnnotationAssertion( dct:creator {{iri}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
-        AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
-        AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
-        AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )
+        AnnotationAssertion( schema:version {{iri}} "{{metadata.version}}" )
+        AnnotationAssertion( schema:dateCreated {{iri}} "{{metadata.creation_date}}" )
+        AnnotationAssertion( dct:license {{iri}} "{{metadata.license}}" )
+        AnnotationAssertion( dct:publisher {{iri}} "{{metadata.publisher}}" )
 
 slots:
   id:

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -22,7 +22,7 @@ default_range: string
 
 imports:
   - linkml:types
-  - ../shared/metadata
+  - ../shared/metadata-base
 
 settings:
   uberon: "UBERON"

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -135,24 +135,13 @@ classes:
   AsctbMetadata:
     class_uri: dcat:Dataset
     slots:
-      - type
-      - name
-      - version
       - title
       - description
       - creators
-      - project_leads
-      - reviewers
-      - externalReviewers
+      - version
       - creation_date
       - license
       - publisher
-      - funders
-      - hubmapId
-      - doi
-      - citation
-      - citationOverall
-      - datatable
   Container:
     tree_root: true
     attributes:
@@ -164,32 +153,15 @@ classes:
         range: AsctbDataset
     annotations:
       owl.template: |-
-        AnnotationAssertion( schema:about {{id}} "{{metadata.type}}" )
-        AnnotationAssertion( schema:name {{id}} "{{metadata.name}}" )
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description|e}}" )
+        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
         AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        {% for l in metadata.project_leads %}
-        AnnotationAssertion( ccf:project_lead {{id}} "{{l.fullName}} ({{l.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.reviewers %}
-        AnnotationAssertion( schema:reviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.externalReviewers %}
-        AnnotationAssertion( ccf:externallyReviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
+        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
         AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
         AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )
-        {% for f in metadata.funders %}
-        AnnotationAssertion( schema:funding {{id}} "Award number {{f.awardNumber}} from {{f.funder}}" )
-        {% endfor %}
-        AnnotationAssertion( ccf:hubmap_id {{id}} "{{metadata.hubmapId}}" )
-        AnnotationAssertion( schema:citation {{id}} "{{metadata.citation}}" )
-        AnnotationAssertion( ccf:citation_overall {{id}} "{{metadata.citationOverall}}" )
 
 slots:
   id:

--- a/schemas/src/digital-objects/collection.yaml
+++ b/schemas/src/digital-objects/collection.yaml
@@ -20,24 +20,13 @@ classes:
   CollectionMetadata:
     class_uri: dcat:Dataset
     slots:
-      - type
-      - name
-      - version
       - title
       - description
       - creators
-      - project_leads
-      - reviewers
-      - externalReviewers
+      - version
       - creation_date
       - license
       - publisher
-      - funders
-      - hubmapId
-      - doi
-      - citation
-      - citationOverall
-      - datatable
   Container:
     tree_root: true
     attributes:
@@ -51,31 +40,12 @@ classes:
         inlined_as_list: true
     annotations:
       owl.template: |-
-        AnnotationAssertion( schema:about {{id}} "{{metadata.type}}" )
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description|e}}" )
+        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
         AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        {% for l in metadata.project_leads %}
-        AnnotationAssertion( ccf:project_lead {{id}} "{{l.fullName}} ({{l.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.reviewers %}
-        AnnotationAssertion( schema:reviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.externalReviewers %}
-        AnnotationAssertion( ccf:externallyReviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
+        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
         AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
         AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )
-        {% for f in metadata.funders %}
-        AnnotationAssertion( schema:funding {{id}} "Award number {{f.awardNumber}} from {{f.funder}}" )
-        {% endfor %}
-        AnnotationAssertion( ccf:hubmap_id {{id}} "{{metadata.hubmapId}}" )
-        AnnotationAssertion( schema:citation {{id}} "{{metadata.citation}}" )
-        AnnotationAssertion( ccf:citation_overall {{id}} "{{metadata.citationOverall}}" )
-        {% for do in data %}
-        AnnotationAssertion( schema:isBasedOn {{id}} https://purl.humanatlas.io/{{do}} )
-        {% endfor %}

--- a/schemas/src/digital-objects/collection.yaml
+++ b/schemas/src/digital-objects/collection.yaml
@@ -14,7 +14,7 @@ default_range: string
 
 imports:
   - linkml:types
-  - ../shared/metadata
+  - ../shared/metadata-base
 
 classes:
   CollectionMetadata:

--- a/schemas/src/digital-objects/collection.yaml
+++ b/schemas/src/digital-objects/collection.yaml
@@ -30,7 +30,7 @@ classes:
   Container:
     tree_root: true
     attributes:
-      id:
+      iri:
         range: uriorcurie
       metadata:
         range: CollectionMetadata
@@ -40,12 +40,12 @@ classes:
         inlined_as_list: true
     annotations:
       owl.template: |-
-        AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
+        AnnotationAssertion( dct:title {{iri}} "{{metadata.title}}" )
+        AnnotationAssertion( dct:description {{iri}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
-        AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
+        AnnotationAssertion( dct:creator {{iri}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
-        AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
-        AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
-        AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )
+        AnnotationAssertion( schema:version {{iri}} "{{metadata.version}}" )
+        AnnotationAssertion( schema:dateCreated {{iri}} "{{metadata.creation_date}}" )
+        AnnotationAssertion( dct:license {{iri}} "{{metadata.license}}" )
+        AnnotationAssertion( dct:publisher {{iri}} "{{metadata.publisher}}" )

--- a/schemas/src/digital-objects/ref-organ.yaml
+++ b/schemas/src/digital-objects/ref-organ.yaml
@@ -14,7 +14,7 @@ default_range: string
 
 imports:
   - linkml:types
-  - ../shared/metadata
+  - ../shared/metadata-base
   
 classes:
   SpatialEntity:

--- a/schemas/src/digital-objects/ref-organ.yaml
+++ b/schemas/src/digital-objects/ref-organ.yaml
@@ -39,7 +39,6 @@ classes:
       - reference_organ
       - extraction_set
       - rui_rank
-
   SpatialObjectReference:
     class_uri: ccf:SpatialObjectReference
     slots:
@@ -82,24 +81,13 @@ classes:
   RefOrganMetadata:
     class_uri: dcat:Dataset
     slots:
-      - type
-      - name
-      - version
       - title
       - description
       - creators
-      - project_leads
-      - reviewers
-      - externalReviewers
+      - version
       - creation_date
       - license
       - publisher
-      - funders
-      - hubmapId
-      - doi
-      - citation
-      - citationOverall
-      - datatable
   Container:
     tree_root: true
     attributes:
@@ -107,51 +95,21 @@ classes:
         range: uriorcurie
       metadata:
         range: RefOrganMetadata
-  
       data:
         multivalued: true
         inlined_as_list: true
         range: SpatialEntity
     annotations:
       owl.template: |-
-        AnnotationAssertion( schema:about {{id}} "{{metadata.type}}" )
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description|e}}" )
+        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
         AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        {% for l in metadata.project_leads %}
-        AnnotationAssertion( ccf:project_lead {{id}} "{{l.fullName}} ({{l.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.reviewers %}
-        AnnotationAssertion( schema:reviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
-        {% for r in metadata.externalReviewers %}
-        AnnotationAssertion( ccf:externallyReviewedBy {{id}} "{{r.fullName}} ({{r.orcid}})" )
-        {% endfor %}
+        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
         AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
         AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
-        AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )
-        {% for f in metadata.funders %}
-        AnnotationAssertion( schema:funding {{id}} "Award number {{f.awardNumber}} from {{f.funder}}" )
-        {% endfor %}
-        AnnotationAssertion( ccf:hubmap_id {{id}} "{{metadata.hubmapId}}" )
-        AnnotationAssertion( schema:citation {{id}} "{{metadata.citation}}" )
-        AnnotationAssertion( ccf:citation_overall {{id}} "{{metadata.citationOverall}}" )
-  
-      # extraction_sets:
-      #   multivalued: true
-      #   inlined_as_list: true
-      #   range: ExtractionSet
-      # spatial_entities:
-      #   multivalued: true
-      #   inlined_as_list: true
-      #   range: SpatialEntity
-      # rui_placements:
-      #   multivalued: true
-      #   inlined_as_list: true
-      #   range: SpatialPlacement
+        AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )  
 
 slots:
   id:
@@ -161,7 +119,7 @@ slots:
     slot_uri: rdfs:label
   creator:
     required: true
-    slot_uri: dcterms:creator
+    slot_uri: ccf:creator
   creator_first_name:
     required: true
     slot_uri: ccf:creator_first_name
@@ -173,7 +131,7 @@ slots:
     slot_uri: ccf:creator_orcid
   creation_date:
     required: true
-    slot_uri: dcterms:created
+    slot_uri: ccf:creation_date
     range: date
   x_dimension:
     required: true
@@ -272,7 +230,7 @@ slots:
     slot_uri: ccf:file_format
   placement_date:
     required: true
-    slot_uri: dcterms:created
+    slot_uri: ccf:placement_date
     range: date
   target:
     required: true
@@ -291,12 +249,12 @@ slots:
     inlined: true
   placement:
     required: true
-    slot_uri: ccf:placement_for
+    slot_uri: ccf:placement
     range: SpatialPlacement
     inlined: true
   placements:
     required: false
-    slot_uri: ccf:placement_for
+    slot_uri: ccf:placements
     range: SpatialPlacement
     inlined: true
     multivalued: true

--- a/schemas/src/digital-objects/ref-organ.yaml
+++ b/schemas/src/digital-objects/ref-organ.yaml
@@ -91,7 +91,7 @@ classes:
   Container:
     tree_root: true
     attributes:
-      id:
+      iri:
         range: uriorcurie
       metadata:
         range: RefOrganMetadata
@@ -101,15 +101,15 @@ classes:
         range: SpatialEntity
     annotations:
       owl.template: |-
-        AnnotationAssertion( dct:title {{id}} "{{metadata.title}}" )
-        AnnotationAssertion( dct:description {{id}} "{{metadata.description}}" )
+        AnnotationAssertion( dct:title {{iri}} "{{metadata.title}}" )
+        AnnotationAssertion( dct:description {{iri}} "{{metadata.description}}" )
         {% for c in metadata.creators %}
-        AnnotationAssertion( dct:creator {{id}} "{{c.fullName}} ({{c.orcid}})" )
+        AnnotationAssertion( dct:creator {{iri}} "{{c.fullName}} ({{c.orcid}})" )
         {% endfor %}
-        AnnotationAssertion( schema:version {{id}} "{{metadata.version}}" )
-        AnnotationAssertion( schema:dateCreated {{id}} "{{metadata.creation_date}}" )
-        AnnotationAssertion( dct:license {{id}} "{{metadata.license}}" )
-        AnnotationAssertion( dct:publisher {{id}} "{{metadata.publisher}}" )  
+        AnnotationAssertion( schema:version {{iri}} "{{metadata.version}}" )
+        AnnotationAssertion( schema:dateCreated {{iri}} "{{metadata.creation_date}}" )
+        AnnotationAssertion( dct:license {{iri}} "{{metadata.license}}" )
+        AnnotationAssertion( dct:publisher {{iri}} "{{metadata.publisher}}" )  
 
 slots:
   id:

--- a/schemas/src/metadata/asct-b-metadata.yaml
+++ b/schemas/src/metadata/asct-b-metadata.yaml
@@ -40,3 +40,21 @@ classes:
       - citation
       - citationOverall
       - datatable
+      - distributions
+    slot_usage:
+      iri:
+        required: true
+      title:
+        required: true
+      description:
+        required: true
+      creators:
+        required: true
+      version:
+        required: true
+      creation_date:
+        required: true
+      license:
+        required: true
+      distributions:
+        required: true

--- a/schemas/src/metadata/asct-b-metadata.yaml
+++ b/schemas/src/metadata/asct-b-metadata.yaml
@@ -1,0 +1,47 @@
+id: https://purl.humanatlas.io/specs/asct-b-metadata
+name: asct-b-metadata
+prefixes:
+  ccf: http://purl.org/ccf/
+  pav: http://purl.org/pav/
+  dcat: http://www.w3.org/ns/dcat#
+  dct: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+  schema: http://schema.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  linkml: https://w3id.org/linkml/
+
+default_prefix: dcat
+default_range: string
+
+imports:
+  - linkml:types
+  - ../shared/metadata-base
+
+classes:
+  AsctbMetadata:
+    class_uri: dcat:Dataset
+    slots:
+      - title
+      - description
+      - creators
+      - project_leads
+      - reviewers
+      - externalReviewers
+      - version
+      - creation_date
+      - license
+      - publisher
+      - funders
+      - hubmapId
+      - doi
+      - citation
+      - citationOverall
+      - datatable
+  Container:
+    tree_root: true
+    attributes:
+      id:
+        range: uriorcurie
+      metadata:
+        range: AsctbMetadata

--- a/schemas/src/metadata/asct-b-metadata.yaml
+++ b/schemas/src/metadata/asct-b-metadata.yaml
@@ -41,7 +41,5 @@ classes:
   Container:
     tree_root: true
     attributes:
-      id:
-        range: uriorcurie
       metadata:
         range: AsctbMetadata

--- a/schemas/src/metadata/asct-b-metadata.yaml
+++ b/schemas/src/metadata/asct-b-metadata.yaml
@@ -23,7 +23,7 @@ classes:
     tree_root: true
     class_uri: dcat:Dataset
     slots:
-      - id
+      - iri
       - title
       - description
       - creators

--- a/schemas/src/metadata/asct-b-metadata.yaml
+++ b/schemas/src/metadata/asct-b-metadata.yaml
@@ -19,9 +19,11 @@ imports:
   - ../shared/metadata-base
 
 classes:
-  AsctbMetadata:
+  Container:
+    tree_root: true
     class_uri: dcat:Dataset
     slots:
+      - id
       - title
       - description
       - creators
@@ -38,8 +40,3 @@ classes:
       - citation
       - citationOverall
       - datatable
-  Container:
-    tree_root: true
-    attributes:
-      metadata:
-        range: AsctbMetadata

--- a/schemas/src/metadata/collection-metadata.yaml
+++ b/schemas/src/metadata/collection-metadata.yaml
@@ -40,3 +40,21 @@ classes:
       - citation
       - citationOverall
       - datatable
+      - distributions
+    slot_usage:
+      iri:
+        required: true
+      title:
+        required: true
+      description:
+        required: true
+      creators:
+        required: true
+      version:
+        required: true
+      creation_date:
+        required: true
+      license:
+        required: true
+      distributions:
+        required: true

--- a/schemas/src/metadata/collection-metadata.yaml
+++ b/schemas/src/metadata/collection-metadata.yaml
@@ -23,7 +23,7 @@ classes:
     tree_root: true
     class_uri: dcat:Dataset
     slots:
-      - id
+      - iri
       - title
       - description
       - creators

--- a/schemas/src/metadata/collection-metadata.yaml
+++ b/schemas/src/metadata/collection-metadata.yaml
@@ -19,9 +19,11 @@ imports:
   - ../shared/metadata-base
 
 classes:
-  CollectionMetadata:
+  Container:
+    tree_root: true
     class_uri: dcat:Dataset
     slots:
+      - id
       - title
       - description
       - creators
@@ -38,8 +40,3 @@ classes:
       - citation
       - citationOverall
       - datatable
-  Container:
-    tree_root: true
-    attributes:
-      metadata:
-        range: CollectionMetadata

--- a/schemas/src/metadata/collection-metadata.yaml
+++ b/schemas/src/metadata/collection-metadata.yaml
@@ -1,0 +1,45 @@
+id: https://purl.humanatlas.io/specs/collection-metadata
+name: collection-metadata
+prefixes:
+  ccf: http://purl.org/ccf/
+  pav: http://purl.org/pav/
+  dcat: http://www.w3.org/ns/dcat#
+  dct: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+  schema: http://schema.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  linkml: https://w3id.org/linkml/
+
+default_prefix: dcat
+default_range: string
+
+imports:
+  - linkml:types
+  - ../shared/metadata-base
+
+classes:
+  CollectionMetadata:
+    class_uri: dcat:Dataset
+    slots:
+      - title
+      - description
+      - creators
+      - project_leads
+      - reviewers
+      - externalReviewers
+      - version
+      - creation_date
+      - license
+      - publisher
+      - funders
+      - hubmapId
+      - doi
+      - citation
+      - citationOverall
+      - datatable
+  Container:
+    tree_root: true
+    attributes:
+      metadata:
+        range: CollectionMetadata

--- a/schemas/src/metadata/ref-organ-metadata.yaml
+++ b/schemas/src/metadata/ref-organ-metadata.yaml
@@ -40,3 +40,21 @@ classes:
       - citation
       - citationOverall
       - datatable
+      - distributions
+    slot_usage:
+      iri:
+        required: true
+      title:
+        required: true
+      description:
+        required: true
+      creators:
+        required: true
+      version:
+        required: true
+      creation_date:
+        required: true
+      license:
+        required: true
+      distributions:
+        required: true

--- a/schemas/src/metadata/ref-organ-metadata.yaml
+++ b/schemas/src/metadata/ref-organ-metadata.yaml
@@ -23,7 +23,7 @@ classes:
     tree_root: true
     class_uri: dcat:Dataset
     slots:
-      - id
+      - iri
       - title
       - description
       - creators

--- a/schemas/src/metadata/ref-organ-metadata.yaml
+++ b/schemas/src/metadata/ref-organ-metadata.yaml
@@ -19,9 +19,11 @@ imports:
   - ../shared/metadata-base
 
 classes:
-  RefOrganMetadata:
+  Container:
+    tree_root: true
     class_uri: dcat:Dataset
     slots:
+      - id
       - title
       - description
       - creators
@@ -38,8 +40,3 @@ classes:
       - citation
       - citationOverall
       - datatable
-  Container:
-    tree_root: true
-    attributes:
-      metadata:
-        range: RefOrganMetadata

--- a/schemas/src/metadata/ref-organ-metadata.yaml
+++ b/schemas/src/metadata/ref-organ-metadata.yaml
@@ -1,0 +1,45 @@
+id: https://purl.humanatlas.io/specs/ref-organ-metadata
+name: ref-organ-metadata
+prefixes:
+  ccf: http://purl.org/ccf/
+  pav: http://purl.org/pav/
+  dcat: http://www.w3.org/ns/dcat#
+  dct: http://purl.org/dc/terms/
+  foaf: http://xmlns.com/foaf/0.1/
+  schema: http://schema.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  linkml: https://w3id.org/linkml/
+
+default_prefix: dcat
+default_range: string
+
+imports:
+  - linkml:types
+  - ../shared/metadata-base
+
+classes:
+  RefOrganMetadata:
+    class_uri: dcat:Dataset
+    slots:
+      - title
+      - description
+      - creators
+      - project_leads
+      - reviewers
+      - externalReviewers
+      - version
+      - creation_date
+      - license
+      - publisher
+      - funders
+      - hubmapId
+      - doi
+      - citation
+      - citationOverall
+      - datatable
+  Container:
+    tree_root: true
+    attributes:
+      metadata:
+        range: RefOrganMetadata

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -2,6 +2,7 @@ id: https://purl.humanatlas.io/specs/metadata-base
 name: metadata-base
 prefixes:
   ccf: http://purl.org/ccf/
+  owl: http://www.w3.org/2002/07/owl#
   pav: http://purl.org/pav/
   dcat: http://www.w3.org/ns/dcat#
   dct: http://purl.org/dc/terms/
@@ -22,7 +23,6 @@ classes:
   Person:
     class_uri: schema:Person
     slots:
-      - id
       - fullName
       - firstName
       - lastName
@@ -34,15 +34,9 @@ classes:
       - awardNumber
 
 slots:
-  id:
-    identifier: true
-    range: uriorcurie
-
   # Schema.org properties
   about:
     slot_uri: schema:about 
-  name:
-    slot_uri: schema:name
   version:
     slot_uri: schema:version
   fullName:
@@ -53,10 +47,7 @@ slots:
     slot_uri: schema:familyName
   orcid:
     slot_uri: schema:identifier
-    pattern: "^10.\d{4,9}/[-._;()/:A-Z0-9]+$"
-  doi:
-    slot_uri: schema:identifier
-    pattern: "^(\d{4}-){3}\d{3}(\d|X)$"
+    pattern: "^(\\d{4}-){3}\\d{3}(\\d|X)$"
   funder:
     slot_uri: schema:funder
   awardNumber:
@@ -89,9 +80,6 @@ slots:
     slot_uri: dct:license
   publisher:
     slot_uri: dct:publisher
-  creator:
-    range: Person
-    slot_uri: dct:creator
   creators:
     multivalued: true
     inlined_as_list: true

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -5,6 +5,7 @@ prefixes:
   pav: http://purl.org/pav/
   dcat: http://www.w3.org/ns/dcat#
   dct: http://purl.org/dc/terms/
+  dc: http://purl.org/dc/elements/1.1/
   foaf: http://xmlns.com/foaf/0.1/
   schema: http://schema.org/
   rdfs: http://www.w3.org/2000/01/rdf-schema#
@@ -19,12 +20,13 @@ imports:
 
 classes:
   Person:
-    class_uri: foaf:Person
+    class_uri: schema:Person
     slots:
+      - id
       - fullName
       - firstName
       - lastName
-      - orcid      
+      - orcid
   Grant:
     class_uri: schema:Grant
     slots:
@@ -32,92 +34,93 @@ classes:
       - awardNumber
 
 slots:
-  type:
-    required: false
-    slot_uri: schema:about    
+  id:
+    identifier: true
+    range: uriorcurie
+
+  # Schema.org properties
+  about:
+    slot_uri: schema:about 
   name:
-    required: false
     slot_uri: schema:name
   version:
-    required: true
     slot_uri: schema:version
-  title:
-    required: true
-    slot_uri: dct:title
-  description:
-    required: true
-    slot_uri: dct:description
-  creators:
-    required: true
-    multivalued: true
-    inlined_as_list: true
-    range: Person
-    slot_uri: dct:creator
-  project_leads:
-    required: false
-    multivalued: true
-    inlined_as_list: true
-    range: Person
-    slot_uri: ccf:project_lead
-  reviewers:
-    required: false
-    multivalued: true
-    inlined_as_list: true
-    range: Person    
-    slot_uri: schema:reviewedBy
-  externalReviewers:
-    required: false
-    multivalued: true
-    inlined_as_list: true
-    range: Person    
-    slot_uri: ccf:externallyReviewedBy
+  fullName:
+    slot_uri: schema:name
+  firstName:
+    slot_uri: schema:givenName
+  lastName:
+    slot_uri: schema:familyName
+  orcid:
+    slot_uri: schema:identifier
+    pattern: "^10.\d{4,9}/[-._;()/:A-Z0-9]+$"
+  doi:
+    slot_uri: schema:identifier
+    pattern: "^(\d{4}-){3}\d{3}(\d|X)$"
+  funder:
+    slot_uri: schema:funder
+  awardNumber:
+    slot_uri: schema:award
+  citation:
+    slot_uri: schema:citation
   creation_date:
-    required: true
     slot_uri: schema:dateCreated
-  license:
-    required: true
-    slot_uri: dct:license
-  publisher:
-    required: false
-    slot_uri: dct:publisher
+  propertyId:
+    slot_uri: schema:propertyID
+  value:
+    slot_uri: schema:value
+  reviewers:
+    multivalued: true
+    inlined_as_list: true
+    range: Person
+    slot_uri: schema:reviewedBy
   funders:
-    required: false
     multivalued: true
     inlined_as_list: true
     range: Grant
     slot_uri: schema:funding
+
+  # Dublin Core properties
+  title:
+    slot_uri: dct:title
+  description:
+    slot_uri: dct:description
+  license:
+    slot_uri: dct:license
+  publisher:
+    slot_uri: dct:publisher
+  creator:
+    range: Person
+    slot_uri: dct:creator
+  creators:
+    multivalued: true
+    inlined_as_list: true
+    range: Person
+    slot_uri: dct:creator
+
+  # OWL properties
+  versionInfo:
+    slot_uri: owl:versionInfo
+
+  # HRA properties
   hubmapId:
-    required: false
     slot_uri: ccf:hubmap_id
   doi:
-    required: false
     range: uriorcurie
     slot_uri: ccf:doi
-  citation:
-    required: false
-    slot_uri: schema:citation
   citationOverall:
-    required: false
     slot_uri: ccf:citation_overall
   datatable:
-    required: false
     multivalued: true
     slot_uri: ccf:data_table
-  fullName:
-    required: true
-    slot_uri: foaf:name
-  firstName:
-    required: true
-    slot_uri: foaf:firstName
-  lastName:
-    required: true
-    slot_uri: foaf:surname
-  orcid:
-    required: true    
-    slot_uri: schema:identifier
-  funder:
-    required: true
-    slot_uri: schema:funder
-  awardNumber:
-    required: false
-    slot_uri: schema:award
+  project_leads:
+    multivalued: true
+    inlined_as_list: true
+    range: Person
+    slot_uri: ccf:project_lead
+  externalReviewers:
+    multivalued: true
+    inlined_as_list: true
+    range: Person    
+    slot_uri: ccf:external_reviewer
+

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -32,10 +32,48 @@ classes:
     slots:
       - funder
       - awardNumber
+  Distribution:
+    class_uri: dcat:Distribution
+    slots:
+      - title
+      - downloadUrl
+      - accessUrl
+      - mediaType
 
 slots:
   iri:
     identifier: true
+
+  # DCAT properties
+  distributions:
+    multivalued: true
+    inlined_as_list: true
+    range: Distribution
+    slot_uri: dcat:distribution
+  downloadUrl:
+    range: uri
+    slot_uri: dcat:downloadURL
+  accessUrl:
+    range: uri
+    slot_uri: dcat:accessURL
+  mediaType:
+    range: uriorcurie
+    slot_uri: dcat:mediaType
+
+  # Dublin Core properties
+  title:
+    slot_uri: dct:title
+  description:
+    slot_uri: dct:description
+  license:
+    slot_uri: dct:license
+  publisher:
+    slot_uri: dct:publisher
+  creators:
+    multivalued: true
+    inlined_as_list: true
+    range: Person
+    slot_uri: dct:creator
 
   # Schema.org properties
   about:
@@ -74,21 +112,6 @@ slots:
     range: Grant
     slot_uri: schema:funding
 
-  # Dublin Core properties
-  title:
-    slot_uri: dct:title
-  description:
-    slot_uri: dct:description
-  license:
-    slot_uri: dct:license
-  publisher:
-    slot_uri: dct:publisher
-  creators:
-    multivalued: true
-    inlined_as_list: true
-    range: Person
-    slot_uri: dct:creator
-
   # OWL properties
   versionInfo:
     slot_uri: owl:versionInfo
@@ -114,4 +137,3 @@ slots:
     inlined_as_list: true
     range: Person    
     slot_uri: ccf:external_reviewer
-

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -34,6 +34,9 @@ classes:
       - awardNumber
 
 slots:
+  id:
+    identifier: true
+
   # Schema.org properties
   about:
     slot_uri: schema:about 

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -1,5 +1,5 @@
-id: https://purl.humanatlas.io/specs/metadata
-name: metadata
+id: https://purl.humanatlas.io/specs/metadata-base
+name: metadata-base
 prefixes:
   ccf: http://purl.org/ccf/
   pav: http://purl.org/pav/

--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -34,7 +34,7 @@ classes:
       - awardNumber
 
 slots:
-  id:
+  iri:
     identifier: true
 
   # Schema.org properties

--- a/scripts/download-ontologies.sh
+++ b/scripts/download-ontologies.sh
@@ -72,7 +72,7 @@ robot convert -i "$MIRROR_DIR/hgnc.owl" \
      -o "$MIRROR_DIR/hgnc.owl"
 
 echo "Downloading the latest RO ontology..."
-curl -L "$OBO_BASE_URL/ro/ro.owl" \
+curl -L "$OBO_BASE_URL/ro/ro-base.owl" \
      --create-dirs -o "$MIRROR_DIR/ro.owl" \
      --retry 4 \
      --max-time 200 && \

--- a/scripts/setup-schemas.sh
+++ b/scripts/setup-schemas.sh
@@ -2,7 +2,7 @@
 set -ev
 
 # Process the edit version of the LinkML schema
-for schemaFile in schemas/src/digital-objects/*.yaml; do
+for schemaFile in schemas/src/{metadata,digital-objects}/*.yaml; do
   type=$(basename ${schemaFile%.yaml})
   echo $type $schemaFile
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ import { list } from './list.js';
 import { normalize } from './normalization/normalize.js';
 import { packageIt } from './packaging/package.js';
 import { getContext, getProcessorVersion, parseDirectory } from './utils/context.js';
+import { error } from './utils/logging.js';
 import { deploy } from './deployment/deploy.js';
 
 const program = new Command();
@@ -29,7 +30,7 @@ program
   )
   .argument('<digital-object-path>', 'Path to the digital object relative to DO_HOME')
   .action((str, _options, command) => {
-    normalize(getContext(program, command, str));
+    normalize(getContext(program, command, str)).catch((e) => error(e));
   });
 
 program

--- a/src/enrichment/enrich-asct-b.js
+++ b/src/enrichment/enrich-asct-b.js
@@ -2,17 +2,28 @@ import { resolve } from 'path';
 import { error, header, info, more } from '../utils/logging.js';
 import { convert, extract, merge, query } from '../utils/robot.js';
 import { throwOnError } from '../utils/sh-exec.js';
-import { cleanTemporaryFiles, convertNormalizedToOwl, logOutput } from './utils.js';
+import { 
+  cleanTemporaryFiles, 
+  convertNormalizedMetadataToRdf,
+  convertNormalizedDataToOwl,
+  logOutput 
+} from './utils.js';
 
-export function enrichAsctb(context) {
-  header(context, 'run-enrich');
+export function enrichAsctbMetadata(context) {
+  const { selectedDigitalObject: obj } = context;
+  const normalizedPath = resolve(obj.path, 'normalized/normalized-metadata.yaml');
+  const enrichedPath = resolve(obj.path, 'enriched/enriched-metadata.ttl');
+  convertNormalizedMetadataToRdf(context, normalizedPath, enrichedPath);
+}
+
+export function enrichAsctbData(context) {
   try {
     const { selectedDigitalObject: obj, processorHome } = context;
 
     // Convert normalized data to graph data (.ttl)
     const normalizedPath = resolve(obj.path, 'normalized/normalized.yaml');
     const baseInputPath = resolve(obj.path, 'enriched/base-input.ttl');
-    convertNormalizedToOwl(context, normalizedPath, baseInputPath);
+    convertNormalizedDataToOwl(context, normalizedPath, baseInputPath);
     logOutput(baseInputPath);
 
     let inputPaths = []; // variable to hold input files for merging

--- a/src/enrichment/enrich-ref-organ.js
+++ b/src/enrichment/enrich-ref-organ.js
@@ -1,24 +1,30 @@
 import { resolve } from 'path';
 import { error, header, info } from '../utils/logging.js';
-import { cleanTemporaryFiles, convertNormalized, convertNormalizedToOwl } from './utils.js';
 import { convert, merge } from '../utils/robot.js';
+import {
+  cleanTemporaryFiles,
+  convertNormalizedMetadataToRdf,
+  convertNormalizedDataToOwl
+} from './utils.js';
 
-export function enrichRefOrgan(context) {
-  header(context, 'run-enrich');
+export function enrichRefOrganMetadata(context) {
   const { selectedDigitalObject: obj } = context;
-  const normalizedPath = resolve(obj.path, 'normalized/normalized.yaml');
-  const ontologyPath = resolve(obj.path, 'enriched/ontology.ttl');
+  const normalizedPath = resolve(obj.path, 'normalized/normalized-metadata.yaml');
+  const enrichedPath = resolve(obj.path, 'enriched/enriched-metadata.ttl');
+  convertNormalizedMetadataToRdf(context, normalizedPath, enrichedPath);
+}
 
+export function enrichRefOrganData(context) {
+  const { selectedDigitalObject: obj } = context;
   try {
-    convertNormalizedToOwl(context, normalizedPath, ontologyPath);
-    convertNormalized(context);
+    const normalizedPath = resolve(obj.path, 'normalized/normalized.yaml');
+    const ontologyPath = resolve(obj.path, 'enriched/ontology.ttl');
+    const enrichedPath = resolve(obj.path, 'enriched/enriched.ttl');
 
-    const turtleEnrichedPath = resolve(obj.path, 'enriched/enriched.ttl');
-    const enrichedPath = resolve(obj.path, 'enriched/enriched.owl');
-    merge([ontologyPath, turtleEnrichedPath], enrichedPath);
-
-    info(`Creating ref-organ: ${turtleEnrichedPath}`);
-    convert(enrichedPath, turtleEnrichedPath, 'ttl');
+    convertNormalizedDataToOwl(context, normalizedPath, ontologyPath);
+    
+    info(`Creating ref-organ: ${enrichedPath}`);
+    convert(ontologyPath, enrichedPath, 'ttl');
   } catch (e) {
     error(e);
   } finally {

--- a/src/enrichment/enrich.js
+++ b/src/enrichment/enrich.js
@@ -1,21 +1,26 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { enrichAsctb } from './enrich-asct-b.js';
-import { enrichCollection } from './enrich-collection.js';
-import { enrichRefOrgan } from './enrich-ref-organ.js';
+import { enrichAsctbMetadata, enrichAsctbData } from './enrich-asct-b.js';
+import { enrichRefOrganMetadata, enrichRefOrganData } from './enrich-ref-organ.js';
+import { enrichCollectionMetadata, enrichCollectionData } from './enrich-collection.js';
+import { header } from '../utils/logging.js';
 
 export function enrich(context) {
   const obj = context.selectedDigitalObject;
   sh.mkdir('-p', resolve(obj.path, 'enriched'));
+  header(context, 'run-enrich');
   switch (obj.type) {
     case 'asct-b':
-      enrichAsctb(context);
-      break;
-    case 'collection':
-      enrichCollection(context);
+      enrichAsctbMetadata(context);
+      enrichAsctbData(context);
       break;
     case 'ref-organ':
-      enrichRefOrgan(context);
+      enrichRefOrganMetadata(context);
+      enrichRefOrganData(context);
+      break;
+    case 'collection':
+      enrichCollectionMetadata(context);
+      enrichCollectionData(context);
       break;
     default:
       console.log(`enrich: "${obj.type}" digital object type not supported (yet)`);

--- a/src/enrichment/utils.js
+++ b/src/enrichment/utils.js
@@ -37,6 +37,15 @@ export function convertNormalizedToOwl(context, inputPath, outputPath) {
   const schemaBackupPath = resolve(processorHome, 'schemas/generated/linkml', `${obj.type}.yaml.bak`);
 
   info(`Using 'linkml-data2owl' to transform ${inputPath}`);
+  /*
+   * The steps:
+   *  1. Substitute the "id" parameter in the schema file (LinkML) with the digital object's IRI, 
+   *     ensuring that the resulting OWL ontology uses the digital object IRI as its ontology IRI.
+   *  2. Employ the linkml-data2owl tool to transform the normalized digital object from YAML into
+   *     OWL format.
+   *  3. Restore the original schema file to its initial state, thereby reinstating the original 
+   *     "id" parameter.
+   */
   throwOnError(
     `sed -i.bak 's|^id:.*|id: ${obj.iri}|' ${schemaPath} && \
      linkml-data2owl --output-type ttl --schema ${schemaPath} ${inputPath} -o ${outputPath} && \

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -16,7 +16,7 @@ import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './ut
 
 const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
-export async function normalizeAsctbMetadata(context) {
+export function normalizeAsctbMetadata(context) {
   const rawMetadata = readMetadata(context);
   writeNormalizedMetadata(context, rawMetadata);
 }

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -3,7 +3,7 @@ import { dump } from 'js-yaml';
 import { resolve } from 'path';
 import sh from 'shelljs';
 import { info, more, warning } from '../utils/logging.js';
-import { validateNormalized } from '../utils/validation.js';
+import { validateNormalizedData } from '../utils/validation.js';
 import {
   getPatchesForAnatomicalStructure,
   getPatchesForBiomarker,
@@ -12,7 +12,7 @@ import {
   isIdValid,
   normalizeDoi
 } from './patches.js';
-import { readMetadata, writeNormalizedMetadata, writeNormalized } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
 
 const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
@@ -21,11 +21,11 @@ export async function normalizeAsctbMetadata(context) {
   writeNormalizedMetadata(context, rawMetadata);
 }
 
-export async function normalizeAsctb(context) {
+export async function normalizeAsctbData(context) {
   const rawData = await getRawData(context);
-  const normalizedData = normalizeRawData(context, rawData);
-  writeNormalized(context, normalizedData);
-  validateNormalized(context);
+  const normalizedData = normalizeData(context, rawData);
+  writeNormalizedData(context, normalizedData);
+  validateNormalizedData(context);
 }
 
 async function getRawData(context) {
@@ -67,7 +67,7 @@ async function getRawData(context) {
   return data.data;
 }
 
-function normalizeRawData(context, data) {
+function normalizeData(context, data) {
   const { excludeBadValues } = context;
   if (excludeBadValues) {
     warning(`Option '--exclude-bad-values' is used to exclude invalid values. The resulting data may be lessen than the raw data.`)

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -17,14 +17,16 @@ const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
 export function normalizeAsctbMetadata(context) {
   const rawMetadata = readMetadata(context);
-  const normalizedMetadata = normalizeMetadata(rawMetadata);
-  writeNormalizedMetadata(context, rawMetadata);
+  const normalizedMetadata = normalizeMetadata(context, rawMetadata);
+  writeNormalizedMetadata(context, normalizedMetadata);
 }
 
-function normalizeMetadata(metadata) {
-  delete metadata.type;
-  delete metadata.name;
-  return metadata;
+function normalizeMetadata(context, metadata) {
+  const { selectedDigitalObject: obj } = context;
+  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  delete normalizedMetadata.type;
+  delete normalizedMetadata.name;
+  return normalizedMetadata;
 }
 
 export async function normalizeAsctbData(context) {

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -11,7 +11,13 @@ import {
   isIdValid,
   normalizeDoi
 } from './patches.js';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
+import {
+  readMetadata,
+  writeNormalizedMetadata,
+  writeNormalizedData,
+  getMetadataIri,
+  getDataDistributions 
+} from './utils.js';
 
 const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
@@ -24,7 +30,8 @@ export function normalizeAsctbMetadata(context) {
 function normalizeMetadata(context, metadata) {
   const normalizedMetadata = {
     iri: getMetadataIri(context),
-     ...metadata
+    ...metadata,
+    distributions: getDataDistributions(context)
   };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -22,6 +22,8 @@ export function normalizeAsctbMetadata(context) {
 }
 
 function normalizeMetadata(metadata) {
+  delete metadata.type;
+  delete metadata.name;
   return metadata;
 }
 

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -23,7 +23,7 @@ export function normalizeAsctbMetadata(context) {
 
 function normalizeMetadata(context, metadata) {
   const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { dump } from 'js-yaml';
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { header, info, more, warning } from '../utils/logging.js';
+import { info, more, warning } from '../utils/logging.js';
 import { validateNormalized } from '../utils/validation.js';
 import {
   getPatchesForAnatomicalStructure,
@@ -12,12 +12,16 @@ import {
   isIdValid,
   normalizeDoi
 } from './patches.js';
-import { readMetadata, writeNormalized } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalized } from './utils.js';
 
 const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
+export async function normalizeAsctbMetadata(context) {
+  const rawMetadata = readMetadata(context);
+  writeNormalizedMetadata(context, rawMetadata);
+}
+
 export async function normalizeAsctb(context) {
-  header(context, 'run-normalize');
   const rawData = await getRawData(context);
   const normalizedData = normalizeRawData(context, rawData);
   writeNormalized(context, normalizedData);

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -18,7 +18,12 @@ const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
 export function normalizeAsctbMetadata(context) {
   const rawMetadata = readMetadata(context);
+  const normalizedMetadata = normalizeMetadata(rawMetadata);
   writeNormalizedMetadata(context, rawMetadata);
+}
+
+function normalizeMetadata(context, metadata) {
+  return metadata;
 }
 
 export async function normalizeAsctbData(context) {

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -11,7 +11,7 @@ import {
   isIdValid,
   normalizeDoi
 } from './patches.js';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
 
 const ASCTB_API = 'https://mmpyikxkcp.us-east-2.awsapprunner.com/';
 
@@ -22,8 +22,10 @@ export function normalizeAsctbMetadata(context) {
 }
 
 function normalizeMetadata(context, metadata) {
-  const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = {
+    iri: getMetadataIri(context),
+     ...metadata
+  };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -3,7 +3,6 @@ import { dump } from 'js-yaml';
 import { resolve } from 'path';
 import sh from 'shelljs';
 import { info, more, warning } from '../utils/logging.js';
-import { validateNormalizedData } from '../utils/validation.js';
 import {
   getPatchesForAnatomicalStructure,
   getPatchesForBiomarker,
@@ -22,7 +21,7 @@ export function normalizeAsctbMetadata(context) {
   writeNormalizedMetadata(context, rawMetadata);
 }
 
-function normalizeMetadata(context, metadata) {
+function normalizeMetadata(metadata) {
   return metadata;
 }
 
@@ -30,7 +29,6 @@ export async function normalizeAsctbData(context) {
   const rawData = await getRawData(context);
   const normalizedData = normalizeData(context, rawData);
   writeNormalizedData(context, normalizedData);
-  validateNormalizedData(context);
 }
 
 async function getRawData(context) {

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -2,33 +2,39 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { resolve } from 'path';
-import { readMetadata, writeNormalizedData } from './utils.js';
-import { validateNormalizedData } from '../utils/validation.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
 import { header } from '../utils/logging.js';
 
-export function normalizeCollection(context) {
-  header(context, 'run-normalize');
+export function normalizeCollectionMetadata(context) {
+  const rawMetadata = readMetadata(context);
+  const normalizedMetadata = normalizeMetadata(rawMetadata);
+  writeNormalizedMetadata(context, rawMetadata);
+}
+
+function normalizeMetadata(metadata) {
+  delete metadata.type;
+  delete metadata.name;
+  return metadata;
+}
+
+export function normalizeCollectionData(context) {
   const { path } = context.selectedDigitalObject;
   const metadata = readMetadata(context);
 
   const dataPath = resolve(path, 'raw', metadata.datatable[0]);
   const data = load(readFileSync(dataPath))['digital-objects'];
+  checkCollectionItems(context, data);
 
   writeNormalizedData(context, data);
-  validateNormalizedData(context);
-
-  validateCollection(context, data);
 }
 
-function validateCollection(context, data) {
+function checkCollectionItems(context, data) {
   let isValid = true;
   if (!context.skipValidation) {
     for (const collectedObj of data) {
       if (!existsSync(resolve(context.doHome, collectedObj, 'raw/metadata.yaml'))) {
-        console.log(chalk.red(collectedObj, 'does not exist or is invalid'));
-        isValid = false;
+        throw new Error(`${collectedObj} does not exist or is invalid`);
       }
     }
   }
-  return isValid;
 }

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { resolve } from 'path';
-import { readMetadata, writeNormalized } from './utils.js';
-import { validateNormalized } from '../utils/validation.js';
+import { readMetadata, writeNormalizedData } from './utils.js';
+import { validateNormalizedData } from '../utils/validation.js';
 import { header } from '../utils/logging.js';
 
 export function normalizeCollection(context) {
@@ -14,8 +14,8 @@ export function normalizeCollection(context) {
   const dataPath = resolve(path, 'raw', metadata.datatable[0]);
   const data = load(readFileSync(dataPath))['digital-objects'];
 
-  writeNormalized(context, data);
-  validateNormalized(context);
+  writeNormalizedData(context, data);
+  validateNormalizedData(context);
 
   validateCollection(context, data);
 }

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -2,8 +2,14 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { resolve } from 'path';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
 import { header, error } from '../utils/logging.js';
+import {
+  readMetadata,
+  writeNormalizedMetadata,
+  writeNormalizedData,
+  getMetadataIri,
+  getDataDistributions
+} from './utils.js';
 
 export function normalizeCollectionMetadata(context) {
   const rawMetadata = readMetadata(context);
@@ -14,7 +20,8 @@ export function normalizeCollectionMetadata(context) {
 function normalizeMetadata(context, metadata) {
   const normalizedMetadata = {
     iri: getMetadataIri(context),
-     ...metadata
+    ...metadata,
+    distributions: getDataDistributions(context)
   };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -7,16 +7,17 @@ import { header } from '../utils/logging.js';
 
 export function normalizeCollectionMetadata(context) {
   const rawMetadata = readMetadata(context);
-  const normalizedMetadata = normalizeMetadata(rawMetadata);
-  writeNormalizedMetadata(context, rawMetadata);
+  const normalizedMetadata = normalizeMetadata(context, rawMetadata);
+  writeNormalizedMetadata(context, normalizedMetadata);
 }
 
-function normalizeMetadata(metadata) {
-  delete metadata.type;
-  delete metadata.name;
-  return metadata;
+function normalizeMetadata(context, metadata) {
+  const { selectedDigitalObject: obj } = context;
+  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  delete normalizedMetadata.type;
+  delete normalizedMetadata.name;
+  return normalizedMetadata;
 }
-
 export function normalizeCollectionData(context) {
   const { path } = context.selectedDigitalObject;
   const metadata = readMetadata(context);

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -13,11 +13,12 @@ export function normalizeCollectionMetadata(context) {
 
 function normalizeMetadata(context, metadata) {
   const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;
 }
+
 export function normalizeCollectionData(context) {
   const { path } = context.selectedDigitalObject;
   const metadata = readMetadata(context);

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { resolve } from 'path';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
 import { header, error } from '../utils/logging.js';
 
 export function normalizeCollectionMetadata(context) {
@@ -12,8 +12,10 @@ export function normalizeCollectionMetadata(context) {
 }
 
 function normalizeMetadata(context, metadata) {
-  const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = {
+    iri: getMetadataIri(context),
+     ...metadata
+  };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;

--- a/src/normalization/normalize-collection.js
+++ b/src/normalization/normalize-collection.js
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { load } from 'js-yaml';
 import { resolve } from 'path';
 import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
-import { header } from '../utils/logging.js';
+import { header, error } from '../utils/logging.js';
 
 export function normalizeCollectionMetadata(context) {
   const rawMetadata = readMetadata(context);
@@ -34,8 +34,11 @@ function checkCollectionItems(context, data) {
   if (!context.skipValidation) {
     for (const collectedObj of data) {
       if (!existsSync(resolve(context.doHome, collectedObj, 'raw/metadata.yaml'))) {
-        throw new Error(`${collectedObj} does not exist or is invalid`);
+        error(`${collectedObj} does not exist or is invalid`);
       }
     }
+  }
+  if (!isValid) {
+    throw new Error(`Cannot normalize ${obj.doString} until all referenced digital objects are found.`);
   }
 }

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -3,7 +3,13 @@ import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { header } from '../utils/logging.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
+import {
+  readMetadata,
+  writeNormalizedMetadata,
+  writeNormalizedData,
+  getMetadataIri,
+  getDataDistributions
+} from './utils.js';
 
 export function normalizeRefOrganMetadata(context) {
   const rawMetadata = readMetadata(context);
@@ -14,7 +20,8 @@ export function normalizeRefOrganMetadata(context) {
 function normalizeMetadata(context, metadata) {
   const normalizedMetadata = {
     iri: getMetadataIri(context),
-     ...metadata
+    ...metadata,
+    distributions: getDataDistributions(context)
   };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -13,7 +13,7 @@ export function normalizeRefOrganMetadata(context) {
 
 function normalizeMetadata(context, metadata) {
   const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -7,14 +7,16 @@ import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './ut
 
 export function normalizeRefOrganMetadata(context) {
   const rawMetadata = readMetadata(context);
-  const normalizedMetadata = normalizeMetadata(rawMetadata);
+  const normalizedMetadata = normalizeMetadata(context, rawMetadata);
   writeNormalizedMetadata(context, normalizedMetadata);
 }
 
-function normalizeMetadata(metadata) {
-  delete metadata.type;
-  delete metadata.name;
-  return metadata;
+function normalizeMetadata(context, metadata) {
+  const { selectedDigitalObject: obj } = context;
+  const normalizedMetadata = { id: `${obj.iri}/${obj.version}`, ...metadata };
+  delete normalizedMetadata.type;
+  delete normalizedMetadata.name;
+  return normalizedMetadata;
 }
 
 export async function normalizeRefOrganData(context) {

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -2,16 +2,16 @@ import { Matrix4 } from '@math.gl/core';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { header } from '../utils/logging.js';
-import { validateNormalized } from '../utils/validation.js';
+import { validateNormalizedData } from '../utils/validation.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
-import { readMetadata, writeNormalized } from './utils.js';
+import { readMetadata, writeNormalizedData } from './utils.js';
 
 export async function normalizeRefOrgan(context) {
   header(context, 'run-normalize');
   const rawData = await getRawData(context);
   const normalizedData = normalizeRawData(context, rawData);
-  writeNormalized(context, normalizedData);
-  validateNormalized(context);
+  writeNormalizedData(context, normalizedData);
+  validateNormalizedData(context);
 }
 
 async function getRawData(context) {

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { header } from '../utils/logging.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
-import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData, getMetadataIri } from './utils.js';
 
 export function normalizeRefOrganMetadata(context) {
   const rawMetadata = readMetadata(context);
@@ -12,8 +12,10 @@ export function normalizeRefOrganMetadata(context) {
 }
 
 function normalizeMetadata(context, metadata) {
-  const { selectedDigitalObject: obj } = context;
-  const normalizedMetadata = { iri: `${obj.iri}/${obj.version}`, ...metadata };
+  const normalizedMetadata = {
+    iri: getMetadataIri(context),
+     ...metadata
+  };
   delete normalizedMetadata.type;
   delete normalizedMetadata.name;
   return normalizedMetadata;

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -2,7 +2,6 @@ import { Matrix4 } from '@math.gl/core';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 import { header } from '../utils/logging.js';
-import { validateNormalizedData } from '../utils/validation.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
 import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
 

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -4,7 +4,19 @@ import { resolve } from 'path';
 import { header } from '../utils/logging.js';
 import { validateNormalizedData } from '../utils/validation.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
-import { readMetadata, writeNormalizedData } from './utils.js';
+import { readMetadata, writeNormalizedMetadata, writeNormalizedData } from './utils.js';
+
+export function normalizeRefOrganMetadata(context) {
+  const rawMetadata = readMetadata(context);
+  const normalizedMetadata = normalizeMetadata(rawMetadata);
+  writeNormalizedMetadata(context, normalizedMetadata);
+}
+
+function normalizeMetadata(metadata) {
+  delete metadata.type;
+  delete metadata.name;
+  return metadata;
+}
 
 export async function normalizeRefOrganData(context) {
   const rawData = await getRawData(context);

--- a/src/normalization/normalize-ref-organ.js
+++ b/src/normalization/normalize-ref-organ.js
@@ -6,12 +6,10 @@ import { validateNormalizedData } from '../utils/validation.js';
 import { processSceneNodes } from './ref-organ-utils/process-scene-nodes.js';
 import { readMetadata, writeNormalizedData } from './utils.js';
 
-export async function normalizeRefOrgan(context) {
-  header(context, 'run-normalize');
+export async function normalizeRefOrganData(context) {
   const rawData = await getRawData(context);
   const normalizedData = normalizeRawData(context, rawData);
   writeNormalizedData(context, normalizedData);
-  validateNormalizedData(context);
 }
 
 async function getRawData(context) {

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { normalizeAsctbMetadata, normalizeAsctb } from './normalize-asct-b.js';
+import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.js';
 import { normalizeCollection } from './normalize-collection.js';
 import { normalizeRefOrgan } from './normalize-ref-organ.js';
 import { header, error } from '../utils/logging.js';
@@ -12,7 +12,7 @@ export async function normalize(context) {
     case 'asct-b':
       header(context, 'run-normalize');
       normalizeAsctbMetadata(context);
-      await normalizeAsctb(context);
+      await normalizeAsctbData(context);
       break;
     case 'collection':
       normalizeCollection(context);

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
 import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.js';
-import { normalizeCollection } from './normalize-collection.js';
+import { normalizeCollectionMetadata, normalizeCollectionData } from './normalize-collection.js';
 import { normalizeRefOrganMetadata, normalizeRefOrganData } from './normalize-ref-organ.js';
 import { validateNormalizedMetadata, validateNormalizedData } from '../utils/validation.js';
 import { header } from '../utils/logging.js';
@@ -20,7 +20,8 @@ export async function normalize(context) {
       await normalizeRefOrganData(context);
       break;
     case 'collection':
-      normalizeCollection(context);
+      normalizeCollectionMetadata(context);
+      normalizeCollectionData(context);
       break;
     default:
       throw new Error(`The "${obj.type}" digital object type not supported (yet).`);

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import sh from 'shelljs';
 import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.js';
 import { normalizeCollection } from './normalize-collection.js';
-import { normalizeRefOrganData } from './normalize-ref-organ.js';
+import { normalizeRefOrganMetadata, normalizeRefOrganData } from './normalize-ref-organ.js';
 import { validateNormalizedMetadata, validateNormalizedData } from '../utils/validation.js';
 import { header, error } from '../utils/logging.js';
 
@@ -26,14 +26,16 @@ export async function normalize(context) {
       }
       break;
     case 'ref-organ':
-      // Produce normalized data
+      // Produce normalized metadata and data
       header(context, 'run-normalize');
+      normalizeRefOrganMetadata(context);
       await normalizeRefOrganData(context);
 
-      // Validate the produced data
+      // Validate the produced metadata and data
       if (skipValidation) {
         info('Skip validation.');
       } else {
+        validateNormalizedMetadata(context);
         validateNormalizedData(context)
       }
       break;

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -1,15 +1,17 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { normalizeAsctb } from './normalize-asct-b.js';
+import { normalizeAsctbMetadata, normalizeAsctb } from './normalize-asct-b.js';
 import { normalizeCollection } from './normalize-collection.js';
 import { normalizeRefOrgan } from './normalize-ref-organ.js';
-import { error } from '../utils/logging.js';
+import { header, error } from '../utils/logging.js';
 
 export async function normalize(context) {
   const obj = context.selectedDigitalObject;
   sh.mkdir('-p', resolve(obj.path, 'normalized'));
   switch (obj.type) {
     case 'asct-b':
+      header(context, 'run-normalize');
+      normalizeAsctbMetadata(context);
       await normalizeAsctb(context);
       break;
     case 'collection':

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import sh from 'shelljs';
 import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.js';
 import { normalizeCollection } from './normalize-collection.js';
-import { normalizeRefOrgan } from './normalize-ref-organ.js';
+import { normalizeRefOrganData } from './normalize-ref-organ.js';
 import { validateNormalizedMetadata, validateNormalizedData } from '../utils/validation.js';
 import { header, error } from '../utils/logging.js';
 
@@ -25,11 +25,20 @@ export async function normalize(context) {
         validateNormalizedData(context);
       }
       break;
+    case 'ref-organ':
+      // Produce normalized data
+      header(context, 'run-normalize');
+      await normalizeRefOrganData(context);
+
+      // Validate the produced data
+      if (skipValidation) {
+        info('Skip validation.');
+      } else {
+        validateNormalizedData(context)
+      }
+      break;
     case 'collection':
       normalizeCollection(context);
-      break;
-    case 'ref-organ':
-      await normalizeRefOrgan(context);
       break;
     default:
       error(`The "${obj.type}" digital object type not supported (yet)`);

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -3,16 +3,27 @@ import sh from 'shelljs';
 import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.js';
 import { normalizeCollection } from './normalize-collection.js';
 import { normalizeRefOrgan } from './normalize-ref-organ.js';
+import { validateNormalizedMetadata, validateNormalizedData } from '../utils/validation.js';
 import { header, error } from '../utils/logging.js';
 
 export async function normalize(context) {
-  const obj = context.selectedDigitalObject;
+  const { selectedDigitalObject: obj, skipValidation } = context;
   sh.mkdir('-p', resolve(obj.path, 'normalized'));
   switch (obj.type) {
     case 'asct-b':
+      // Produce normalized metadata and data
       header(context, 'run-normalize');
       normalizeAsctbMetadata(context);
       await normalizeAsctbData(context);
+
+      // Validate the produced normalized metadata and data
+      header(context, 'run-validation');
+      if (skipValidation) {
+        info('Skip validation.');
+      } else {
+        validateNormalizedMetadata(context);
+        validateNormalizedData(context);
+      }
       break;
     case 'collection':
       normalizeCollection(context);

--- a/src/normalization/normalize.js
+++ b/src/normalization/normalize.js
@@ -4,46 +4,38 @@ import { normalizeAsctbMetadata, normalizeAsctbData } from './normalize-asct-b.j
 import { normalizeCollection } from './normalize-collection.js';
 import { normalizeRefOrganMetadata, normalizeRefOrganData } from './normalize-ref-organ.js';
 import { validateNormalizedMetadata, validateNormalizedData } from '../utils/validation.js';
-import { header, error } from '../utils/logging.js';
+import { header } from '../utils/logging.js';
 
 export async function normalize(context) {
-  const { selectedDigitalObject: obj, skipValidation } = context;
+  const { selectedDigitalObject: obj } = context;
   sh.mkdir('-p', resolve(obj.path, 'normalized'));
+  header(context, 'run-normalize');
   switch (obj.type) {
     case 'asct-b':
-      // Produce normalized metadata and data
-      header(context, 'run-normalize');
       normalizeAsctbMetadata(context);
       await normalizeAsctbData(context);
-
-      // Validate the produced normalized metadata and data
-      header(context, 'run-validation');
-      if (skipValidation) {
-        info('Skip validation.');
-      } else {
-        validateNormalizedMetadata(context);
-        validateNormalizedData(context);
-      }
       break;
     case 'ref-organ':
-      // Produce normalized metadata and data
-      header(context, 'run-normalize');
       normalizeRefOrganMetadata(context);
       await normalizeRefOrganData(context);
-
-      // Validate the produced metadata and data
-      if (skipValidation) {
-        info('Skip validation.');
-      } else {
-        validateNormalizedMetadata(context);
-        validateNormalizedData(context)
-      }
       break;
     case 'collection':
       normalizeCollection(context);
       break;
     default:
-      error(`The "${obj.type}" digital object type not supported (yet)`);
-      break;
+      throw new Error(`The "${obj.type}" digital object type not supported (yet).`);
+  }
+  // Validate the produced metadata and data
+  validate(context);
+}
+
+function validate(context) {
+  const { skipValidation } = context;
+  header(context, 'run-validation');
+  if (skipValidation) {
+    info('Skip validation.');
+  } else {
+    validateNormalizedMetadata(context);
+    validateNormalizedData(context);
   }
 }

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -28,7 +28,7 @@ export function writeNormalizedData(context, data) {
   const normalizedPath = resolve(path, 'normalized/normalized.yaml');
   writeFileSync(
     normalizedPath,
-    dump({ id: iri, metadata, data })
+    dump({ iri, metadata, data })
   );
   info(`Normalized digital object written to ${normalizedPath}`);
 }

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -21,7 +21,7 @@ export function writeNormalizedMetadata(context, metadata) {
   info(`Normalized metadata written to ${normalizedPath}`);
 }
 
-export function writeNormalized(context, data) {
+export function writeNormalizedData(context, data) {
   const { path, iri } = context.selectedDigitalObject;
   const metadata = selectMetadata(readMetadata(context));
 

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -11,6 +11,16 @@ export function readMetadata(context) {
   }
 }
 
+export function writeNormalizedMetadata(context, metadata) {
+  const { path, iri } = context.selectedDigitalObject;
+  const normalizedPath = resolve(path, 'normalized/normalized-metadata.yaml');
+  writeFileSync(
+    normalizedPath,
+    dump({ metadata })
+  );
+  info(`Normalized metadata written to ${normalizedPath}`);
+}
+
 export function writeNormalized(context, data) {
   const { path, iri } = context.selectedDigitalObject;
   const metadata = selectMetadata(readMetadata(context));

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -37,7 +37,44 @@ function selectMetadata({title, description, creators, version, creation_date, l
   return { title, description, creators, version, creation_date, license, publisher };
 }
 
+export function getDataDistributions(context) {
+  const { selectedDigitalObject: obj } = context;
+  const accessUrl = getMetadataIri(context);
+  return [{
+      title: `The data distribution of '${obj.doString}' in Turtle format.`,
+      downloadUrl: getDataDownloadUrl(context, 'ttl'),
+      accessUrl: accessUrl,
+      mediaType: "text/turtle"
+    }, {
+      title: `The data distribution of '${obj.doString}' in JSON-LD format.`,
+      downloadUrl: getDataDownloadUrl(context, 'json'),
+      accessUrl: accessUrl,
+      mediaType: "application/ld+json"
+    }, {
+      title: `The data distribution of '${obj.doString}' in RDF/XML format.`,
+      downloadUrl: getDataDownloadUrl(context, 'xml'),
+      accessUrl: accessUrl,
+      mediaType: "application/rdf+xml"
+    }, {
+      title: `The data distribution of '${obj.doString}' in N-Triples format.`,
+      downloadUrl: getDataDownloadUrl(context, 'nt'),
+      accessUrl: accessUrl,
+      mediaType: "application/n-triples"
+    }, {
+      title: `The data distribution of '${obj.doString}' in N-Quads format.`,
+      downloadUrl: getDataDownloadUrl(context, 'nquads'),
+      accessUrl: accessUrl,
+      mediaType: "application/n-quads"
+    }];
+}
+
 export function getMetadataIri(context) {
   const { type, name, version } = context.selectedDigitalObject;
   return `https://lod.humanatlas.io/${type}/${name}/${version}`;
 }
+
+function getDataDownloadUrl(context, format='ttl') {
+  const { type, name, version } = context.selectedDigitalObject;
+  return `https://cdn.humanatlas.io/digital-objects/${type}/${name}/${version}/graph.${format}`;
+}
+

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -13,7 +13,7 @@ export function readMetadata(context) {
 
 export function writeNormalized(context, data) {
   const { path, iri } = context.selectedDigitalObject;
-  const metadata = readMetadata(context);
+  const metadata = selectMetadata(readMetadata(context));
 
   const normalizedPath = resolve(path, 'normalized/normalized.yaml');
   writeFileSync(
@@ -21,4 +21,8 @@ export function writeNormalized(context, data) {
     dump({ id: iri, metadata, data })
   );
   info(`Normalized digital object written to ${normalizedPath}`);
+}
+
+function selectMetadata({title, description, creators, version, creation_date, license, publisher }) {
+  return { title, description, creators, version, creation_date, license, publisher };
 }

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -36,3 +36,8 @@ export function writeNormalizedData(context, data) {
 function selectMetadata({title, description, creators, version, creation_date, license, publisher }) {
   return { title, description, creators, version, creation_date, license, publisher };
 }
+
+export function getMetadataIri(context) {
+  const { type, name, version } = context.selectedDigitalObject;
+  return `https://lod.humanatlas.io/${type}/${name}/${version}`;
+}

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -12,11 +12,11 @@ export function readMetadata(context) {
 }
 
 export function writeNormalizedMetadata(context, metadata) {
-  const { path, iri } = context.selectedDigitalObject;
+  const { path } = context.selectedDigitalObject;
   const normalizedPath = resolve(path, 'normalized/normalized-metadata.yaml');
   writeFileSync(
     normalizedPath,
-    dump({ metadata })
+    dump(metadata)
   );
   info(`Normalized metadata written to ${normalizedPath}`);
 }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -6,7 +6,7 @@ import sh from 'shelljs';
 import { logOnError } from './sh-exec.js';
 import { header, info } from './logging.js';
 
-export function validateNormalized(context) {
+export function validateNormalizedData(context) {
   const { selectedDigitalObject: obj, processorHome, skipValidation } = context;
 
   header(context, 'run-validation');


### PR DESCRIPTION
Implementing metadata schema for existing digital objects based on DCAT data model and vocabulary. The schema specification is written in the LinkML language, including:

* asct-b-metadata.yaml
* ref-organ-metadata.yaml
* collection-metadata.yaml
* metadata-base.yaml

The implementation also includes a new extension to the normalization and enrichment pipelines, which entails preprocessing the raw input metadata to align with the metadata schema within the normalization pipeline, followed by its conversion into RDF data within the enrichment pipeline.

Additionally, certain portions of the code were refactored to enhance optimization and improve code clarity.