### PR TITLE
Reverting back the asctb schema

### DIFF
--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -130,7 +130,7 @@ classes:
         annotations:
           owl: AnnotationAssertion, AnnotationProperty
 
-  AnatomicalStructureColumnInstance:
+  AnatomicalStructureRecord:
     mixins:
       - Named
       - Instance
@@ -140,7 +140,7 @@ classes:
       - record_number
       - order_number
 
-  CellTypeColumnInstance:
+  CellTypeRecord:
     mixins:
       - Named
       - Instance
@@ -150,7 +150,7 @@ classes:
       - record_number
       - order_number
 
-  BiomarkerColumnInstance:
+  BiomarkerRecord:
     mixins:
       - Named
       - Instance
@@ -370,7 +370,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: AnatomicalStructureColumnInstance
+    range: AnatomicalStructureRecord
     slot_uri: ccf:anatomical_structure
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -380,7 +380,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: CellTypeColumnInstance
+    range: CellTypeRecord
     slot_uri: ccf:cell_type
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -390,7 +390,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerColumnInstance
+    range: BiomarkerRecord
     slot_uri: ccf:gene_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -400,7 +400,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerColumnInstance
+    range: BiomarkerRecord
     slot_uri: ccf:protein_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -410,7 +410,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerColumnInstance
+    range: BiomarkerRecord
     slot_uri: ccf:lipid_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -420,7 +420,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerColumnInstance
+    range: BiomarkerRecord
     slot_uri: ccf:metabolite_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -430,7 +430,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerColumnInstance
+    range: BiomarkerRecord
     slot_uri: ccf:proteoform_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -116,49 +116,48 @@ classes:
       - Instance
     slots:
       - record_number
-      - as_records
-      - ct_records
-      - bg_records
-      - bp_records
-      - bl_records
-      - bm_records
-      - bf_records
-      - ref_records
+      - anatomical_structure_list
+      - cell_type_list
+      - gene_marker_list
+      - protein_marker_list
+      - lipid_marker_list
+      - metabolites_marker_list
+      - proteoforms_marker_list
+      - references
+    slot_usage:
+      references:
+        range: string
+        annotations:
+          owl: AnnotationAssertion, AnnotationProperty
 
-  AnatomicalStructureRecord:
+  AnatomicalStructureInstance:
     mixins:
       - Named
       - Instance
     slots:
-      - concept_value
+      - ccf_pref_label
+      - source_concept
       - record_number
       - order_number
 
-  CellTypeRecord:
+  CellTypeInstance:
     mixins:
       - Named
       - Instance
     slots:
-      - concept_value
+      - ccf_pref_label
+      - source_concept
       - record_number
       - order_number
 
-  BiomarkerRecord:
+  BiomarkerInstance:
     mixins:
       - Named
       - Instance
     slots:
-      - concept_value
+      - ccf_pref_label
       - ccf_biomarker_type
-      - record_number
-      - order_number
-
-  ReferenceRecord:
-    mixins:
-      - Named
-      - Instance
-    slots:
-      - string_value
+      - source_concept
       - record_number
       - order_number
 
@@ -167,9 +166,9 @@ classes:
       - Named
       - Instance
     slots:
-      - targeted_cell_type
-      - cell_type_location
-      - characterizing_biomarkers
+      - primary_cell_type
+      - primary_anatomical_structure
+      - biomarker_set
       - references
       - source_record
     slot_usage:
@@ -339,18 +338,14 @@ slots:
     slot_uri: ccf:ccf_biomarker_type
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  concept_value:
-    title: concept value
-    description: Reference to a concept by its standard URI.
-    slot_uri: ccf:concept_value
-    range: AsctbConcept
+  source_concept:
+    title: source concept
+    description: >-
+      Source concept providing the origin of this record within the 
+      ASCT-B model.
     required: true
-    annotations:
-      owl: AnnotationAssertion, AnnotationProperty
-  string_value:
-    title: string value
-    description: A string-typed value.
-    slot_uri: ccf:string_value
+    slot_uri: ccf:source_concept
+    range: AsctbConcept
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
   record_number:
@@ -369,109 +364,97 @@ slots:
     range: integer
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  as_records:
-    title: anatomical structure record
-    description: List of anatomical structures in an ASCT+B record instance.
-    slot_uri: ccf:as_record
-    range: AnatomicalStructureRecord
+  anatomical_structure_list:
+    title: anatomical structure
+    description: List of anatomical structure instances related to ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: AnatomicalStructureInstance
+    slot_uri: ccf:anatomical_structure
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  ct_records:
-    title: cell type record
-    description: List of cell types in an ASCT+B record instance.
-    slot_uri: ccf:ct_record
-    range: CellTypeRecord
+  cell_type_list:
+    title: cell type
+    description: List of cell type instances associated with ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: CellTypeInstance
+    slot_uri: ccf:cell_type
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  bg_records:
-    title: gene marker record
-    description: List of gene markers in an ASCT+B record instance.
-    slot_uri: ccf:bg_record
-    range: BiomarkerRecord
+  gene_marker_list:
+    title: gene marker
+    description: List of gene markers referenced within ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: BiomarkerInstance
+    slot_uri: ccf:gene_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  bp_records:
-    title: protein marker record
-    description: List of protein markers in an ASCT+B record instance.
-    slot_uri: ccf:bp_record
-    range: BiomarkerRecord
+  protein_marker_list:
+    title: protein marker
+    description: List of protein markers referenced within ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: BiomarkerInstance
+    slot_uri: ccf:protein_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  bl_records:
-    title: lipid marker record
-    description: List of lipid markers in an ASCT+B record instance.
-    slot_uri: ccf:bl_record
-    range: BiomarkerRecord
+  lipid_marker_list:
+    title: lipid marker
+    description: List of lipid markers referenced within ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: BiomarkerInstance
+    slot_uri: ccf:lipid_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  bm_records:
-    title: metabolite marker record
-    description: List of metabolites markers in an ASCT+B record instance.
-    slot_uri: ccf:bm_record
-    range: BiomarkerRecord
+  metabolites_marker_list:
+    title: metabolite marker
+    description: List of metabolites markers referenced within ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: BiomarkerInstance
+    slot_uri: ccf:metabolite_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  bf_records:
-    title: proteoform marker record
-    description: List of proteoforms markers in an ASCT+B record instance.
-    slot_uri: ccf:bf_record
-    range: BiomarkerRecord
+  proteoforms_marker_list:
+    title: proteoform marker
+    description: List of proteoforms markers referenced within ASCT-B records.
     required: false
     multivalued: true
     inlined_as_list: true
+    range: BiomarkerInstance
+    slot_uri: ccf:proteoform_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  ref_records:
-    title: reference record
-    description: List of references in an ASCT+B record instance.
-    slot_uri: ccf:ref_record
-    range: ReferenceRecord
-    required: false
-    multivalued: true
-    inlined_as_list: true
-    annotations:
-      owl: AnnotationAssertion, AnnotationProperty
-  targeted_cell_type:
-    title: targeted cell type
-    description: >-
-      Targeted cell type associated with a cell marker descriptor.
-    required: true
+  primary_cell_type:
+    title: primary cell type
+    description: The cell type in the cell marker descriptor.
     range: CellType
-    annotations:
-      owl: AnnotationAssertion, AnnotationProperty
-  cell_type_location:
-    title: cell type location
-    description: >-
-      The anatomical structure associated with a cell marker descriptor.
     required: true
-    range: AnatomicalStructure
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
-  characterizing_biomarkers:
-    title: characterizing biomarker
+  primary_anatomical_structure:
+    title: primary anatomical structure
+    description: The anatomical structure in the cell marker descriptor.
+    range: AnatomicalStructure
+    required: true
+    annotations:
+      owl: AnnotationAssertion, AnnotationProperty
+  biomarker_set:
+    title: biomarker set
     description: >-
-      Collection of biomarkers in the ASCT-B cell marker descriptor.
-    slot_uri: ccf:characterizing_biomarker
-    multivalued: true
+      Collection of characterizing biomarker set in the cell marker descriptor.
+    slot_uri: ccf:biomarker
     range: Biomarker
+    multivalued: true
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
   source_record:

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -130,7 +130,7 @@ classes:
         annotations:
           owl: AnnotationAssertion, AnnotationProperty
 
-  AnatomicalStructureInstance:
+  AnatomicalStructureColumnInstance:
     mixins:
       - Named
       - Instance
@@ -140,7 +140,7 @@ classes:
       - record_number
       - order_number
 
-  CellTypeInstance:
+  CellTypeColumnInstance:
     mixins:
       - Named
       - Instance
@@ -150,7 +150,7 @@ classes:
       - record_number
       - order_number
 
-  BiomarkerInstance:
+  BiomarkerColumnInstance:
     mixins:
       - Named
       - Instance
@@ -370,7 +370,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: AnatomicalStructureInstance
+    range: AnatomicalStructureColumnInstance
     slot_uri: ccf:anatomical_structure
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -380,7 +380,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: CellTypeInstance
+    range: CellTypeColumnInstance
     slot_uri: ccf:cell_type
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -390,7 +390,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerInstance
+    range: BiomarkerColumnInstance
     slot_uri: ccf:gene_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -400,7 +400,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerInstance
+    range: BiomarkerColumnInstance
     slot_uri: ccf:protein_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -410,7 +410,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerInstance
+    range: BiomarkerColumnInstance
     slot_uri: ccf:lipid_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -420,7 +420,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerInstance
+    range: BiomarkerColumnInstance
     slot_uri: ccf:metabolite_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
@@ -430,7 +430,7 @@ slots:
     required: false
     multivalued: true
     inlined_as_list: true
-    range: BiomarkerInstance
+    range: BiomarkerColumnInstance
     slot_uri: ccf:proteoform_marker
     annotations:
       owl: AnnotationAssertion, AnnotationProperty

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -265,6 +265,7 @@ function normalizeBm(collector, { id: bm_id, name: bm_name, b_type, is_provision
 }
 
 function normalizeAsctbRecord(context, data) {
+  const { name: doName } = context.selectedDigitalObject
   return data.reduce((collector, row, index) => {
     // Determine record number
     const recordNumber = index + 1;
@@ -294,7 +295,7 @@ function normalizeAsctbRecord(context, data) {
     // Collect all the items
     collector.push({
       id: generateAsctbRecordId(context, recordNumber),
-      label: `Record ${recordNumber}`,
+      label: `Table ${doName}, Record ${recordNumber}`,
       type_of: [`AsctbRecord`],
       record_number: recordNumber,
       anatomical_structure_list: asInstances,
@@ -369,7 +370,7 @@ function generateAsInstance(context, recordNumber, data, index) {
   const orderNumber = index + 1
   return {
     id: generateAsInstanceId(context, recordNumber, orderNumber),
-    label: `${asName} (${doName}-R${recordNumber}-AS${orderNumber})`,
+    label: `${asName} (Table ${doName}, Record ${recordNumber}, Column AS/${orderNumber})`,
     type_of: ['AnatomicalStructureColumnInstance'],
     ccf_pref_label: asName,
     source_concept: generateIdWhenEmpty(id, asName),
@@ -385,7 +386,7 @@ function generateCtInstance(context, recordNumber, data, index) {
   const orderNumber = index + 1
   return {
     id: generateCtInstanceId(context, recordNumber, orderNumber),
-    label: `${ctName} (${doName}-R${recordNumber}-CT${orderNumber})`,
+    label: `${ctName} (Table ${doName}, Record ${recordNumber}, Column CT/${orderNumber})`,
     type_of: ['CellTypeColumnInstance'],
     ccf_pref_label: ctName,
     source_concept: generateIdWhenEmpty(id, ctName),
@@ -401,7 +402,7 @@ function generateBmInstance(context, recordNumber, data, index) {
   const orderNumber = index + 1
   return {
     id: generateBmInstanceId(context, recordNumber, orderNumber),
-    label: `${bmName} (${doName}-R${recordNumber}-BM${orderNumber})`,
+    label: `${bmName} (Table ${doName}, Record ${recordNumber}, Column BM/${orderNumber})`,
     type_of: ['BiomarkerColumnInstance'],
     ccf_pref_label: bmName,
     ccf_biomarker_type: b_type,

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -265,45 +265,46 @@ function normalizeBm(collector, { id: bm_id, name: bm_name, b_type, is_provision
 }
 
 function normalizeAsctbRecord(context, data) {
-  const { name } = context.selectedDigitalObject
-  const tableName = capitalize(name);
   return data.reduce((collector, row, index) => {
     // Determine record number
     const recordNumber = index + 1;
 
     // Generate anatomical structure instances
-    const asRecords = row.anatomical_structures
-      .map((item, order) => generateAsRecord(context, tableName, recordNumber, item, order))
-      .filter(({ concept_value }) => passAsIdFilterCriteria(context, concept_value));
+    const asInstances = row.anatomical_structures
+      .map((item, order) => generateAsInstance(context, recordNumber, item, order))
+      .filter(({ source_concept }) => passAsIdFilterCriteria(context, source_concept));
 
     // Generate cell type instances
-    const ctRecords = row.cell_types
-      .map((item, order) => generateCtRecord(context, tableName, recordNumber, item, order))
-      .filter(({ concept_value }) => passCtIdFilterCriteria(context, concept_value));
+    const ctInstances = row.cell_types
+      .map((item, order) => generateCtInstance(context, recordNumber, item, order))
+      .filter(({ source_concept }) => passCtIdFilterCriteria(context, source_concept));
 
     // Generate biomarker instances
-    const bmRecords = row.biomarkers
-      .map((item, order) => generateBmRecord(context, tableName, recordNumber, item, order))
-      .filter(({ concept_value }) => passIdFilterCriteria(context, concept_value));
+    const bmInstances = row.biomarkers
+      .map((item, order) => generateBmInstance(context, recordNumber, item, order))
+      .filter(({ source_concept }) => passIdFilterCriteria(context, source_concept));
 
     // Populate all valid references
-    const refRecords = row.references
-      .map((item, order) => generateRefRecord(context, tableName, recordNumber, item, order));
+    const references = row.references
+      .map((ref) => {
+        const refString = checkNotEmpty(ref.id) ? ref.id : "N/A";
+        return checkIsDoi(refString) ? normalizeDoi(refString) : normalizeString(refString);
+      });
 
     // Collect all the items
     collector.push({
       id: generateAsctbRecordId(context, recordNumber),
-      label: `${tableName} table, Record ${recordNumber}`,
+      label: `Record ${recordNumber}`,
       type_of: [`AsctbRecord`],
       record_number: recordNumber,
-      as_records: asRecords,
-      ct_records: ctRecords,
-      bg_records: bmRecords.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.G),
-      bp_records: bmRecords.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.P),
-      bl_records: bmRecords.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BL),
-      bm_records: bmRecords.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BM),
-      bf_records: bmRecords.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BF),
-      ref_records: refRecords
+      anatomical_structure_list: asInstances,
+      cell_type_list: ctInstances,
+      gene_marker_list: bmInstances.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.G),
+      protein_marker_list: bmInstances.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.P),
+      lipid_marker_list: bmInstances.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BL),
+      metabolites_marker_list: bmInstances.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BM),
+      proteoforms_marker_list: bmInstances.filter(({ ccf_biomarker_type }) => ccf_biomarker_type === BM_TYPE.BF),
+      references: references
     });
     return collector;
   }, []);
@@ -350,9 +351,9 @@ function normalizeCellMarkerDescriptor(context, data) {
         id: generateCellMarkerDescriptorId(context, recordNumber),
         label: `Cell marker descriptor for ${primaryCt.name}`,
         type_of: [`CellMarkerDescriptor`],
-        targeted_cell_type: primaryCt.id,
-        cell_type_location: primaryAs,
-        characterizing_biomarkers: biomarkers,
+        primary_cell_type: primaryCt.id,
+        primary_anatomical_structure: primaryAs,
+        biomarker_set: biomarkers,
         references: references,
         source_record: generateAsctbRecordId(context, recordNumber)
       });
@@ -361,65 +362,50 @@ function normalizeCellMarkerDescriptor(context, data) {
   }, []);
 }
 
-function generateAsRecord(context, tableName, recordNumber, data, index) {
+function generateAsInstance(context, recordNumber, data, index) {
+  const { name: doName } = context.selectedDigitalObject
   const { id, name } = data;
   const asName = normalizeString(name);
-  const orderNumber = index + 1;
-  const columnName = "AS";
+  const orderNumber = index + 1
   return {
-    id: generateAsctbColumnRecordId(context, recordNumber, orderNumber, columnName),
-    label: `${tableName} table, Record ${recordNumber}, Column ${columnName}/${orderNumber}`,
-    type_of: ['AnatomicalStructureRecord'],
-    concept_value: generateIdWhenEmpty(id, asName),
+    id: generateAsInstanceId(context, recordNumber, orderNumber),
+    label: `${asName} (${doName}-R${recordNumber}-AS${orderNumber})`,
+    type_of: [generateIdWhenEmpty(id, asName)],
+    ccf_pref_label: asName,
+    source_concept: generateIdWhenEmpty(id, asName),
     record_number: recordNumber,
     order_number: orderNumber
   }
 }
 
-function generateCtRecord(context, tableName, recordNumber, data, index) {
+function generateCtInstance(context, recordNumber, data, index) {
+  const { name: doName } = context.selectedDigitalObject
   const { id, name } = data;
   const ctName = normalizeString(name);
-  const orderNumber = index + 1;
-  const columnName = "CT";
+  const orderNumber = index + 1
   return {
-    id: generateAsctbColumnRecordId(context, recordNumber, orderNumber, columnName),
-    label: `${tableName} table, Record ${recordNumber}, Column ${columnName}/${orderNumber}`,
-    type_of: ['CellTypeRecord'],
-    concept_value: generateIdWhenEmpty(id, ctName),
+    id: generateCtInstanceId(context, recordNumber, orderNumber),
+    label: `${ctName} (${doName}-R${recordNumber}-CT${orderNumber})`,
+    type_of: [generateIdWhenEmpty(id, ctName)],
+    ccf_pref_label: ctName,
+    source_concept: generateIdWhenEmpty(id, ctName),
     record_number: recordNumber,
     order_number: orderNumber
   }
 }
 
-function generateBmRecord(context, tableName, recordNumber, data, index) {
+function generateBmInstance(context, recordNumber, data, index) {
+  const { name: doName } = context.selectedDigitalObject
   const { id, name, b_type } = data;
   const bmName = normalizeString(name);
-  const orderNumber = index + 1;
-  const columnName = "BM";
-  return {
-    id: generateAsctbColumnRecordId(context, recordNumber, orderNumber, columnName),
-    label: `${tableName} table, Record ${recordNumber}, Column ${columnName}/${orderNumber}`,
-    type_of: ['BiomarkerRecord'],
-    ccf_biomarker_type: b_type,
-    concept_value: generateIdWhenEmpty(id, bmName),
-    record_number: recordNumber,
-    order_number: orderNumber
-  }
-}
-
-function generateRefRecord(context, tableName, recordNumber, data, index) {
-  const { id } = data;
-  const refString = checkNotEmpty(id) ? id : "N/A";
-  const normalizeRefString = checkIsDoi(refString) 
-      ? normalizeDoi(refString) 
-      : normalizeString(refString);
   const orderNumber = index + 1
-  const columnName = "REF";
   return {
-    id: generateAsctbColumnRecordId(context, recordNumber, orderNumber, columnName),
-    label: `${tableName} table, Record ${recordNumber}, Column ${columnName}/${orderNumber}`,
-    type_of: ['ReferenceRecord'],
-    string_value: normalizeRefString,
+    id: generateBmInstanceId(context, recordNumber, orderNumber),
+    label: `${bmName} (${doName}-R${recordNumber}-BM${orderNumber})`,
+    type_of: [generateIdWhenEmpty(id, bmName)],
+    ccf_pref_label: bmName,
+    ccf_biomarker_type: b_type,
+    source_concept: generateIdWhenEmpty(id, bmName),
     record_number: recordNumber,
     order_number: orderNumber
   }
@@ -430,9 +416,19 @@ function generateAsctbRecordId(context, recordNumber) {
   return `${context.purlIri}${doType}/${doName}/${doVersion}#R${recordNumber}`;
 }
 
-function generateAsctbColumnRecordId(context, recordNumber, orderNumber, columnName) {
+function generateAsInstanceId(context, recordNumber, orderNumber) {
   const { type: doType, name: doName, version: doVersion } = context.selectedDigitalObject;
-  return `${context.purlIri}${doType}/${doName}/${doVersion}#R${recordNumber}-${columnName}${orderNumber}`;
+  return `${context.purlIri}${doType}/${doName}/${doVersion}#R${recordNumber}-AS${orderNumber}`;
+}
+
+function generateCtInstanceId(context, recordNumber, orderNumber) {
+  const { type: doType, name: doName, version: doVersion } = context.selectedDigitalObject;
+  return `${context.purlIri}${doType}/${doName}/${doVersion}#R${recordNumber}-CT${orderNumber}`;
+}
+
+function generateBmInstanceId(context, recordNumber, orderNumber) {
+  const { type: doType, name: doName, version: doVersion } = context.selectedDigitalObject;
+  return `${context.purlIri}${doType}/${doName}/${doVersion}#R${recordNumber}-BM${orderNumber}`;
 }
 
 function generateCellMarkerDescriptorId(context, recordNumber) {
@@ -446,10 +442,6 @@ function generateIdWhenEmpty(id, name) {
 
 function generateId(name) {
   return `https://purl.org/ccf/ASCTB-TEMP_${normalizeName(name)}`;
-}
-
-function capitalize(word) {
-  return word.replace(/^\w/, (c) => c.toUpperCase());
 }
 
 function normalizeName(name) {

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -371,7 +371,7 @@ function generateAsInstance(context, recordNumber, data, index) {
   return {
     id: generateAsInstanceId(context, recordNumber, orderNumber),
     label: `${asName} (Table ${doName}, Record ${recordNumber}, Column AS/${orderNumber})`,
-    type_of: ['AnatomicalStructureColumnInstance'],
+    type_of: ['AnatomicalStructureRecord'],
     ccf_pref_label: asName,
     source_concept: generateIdWhenEmpty(id, asName),
     record_number: recordNumber,
@@ -387,7 +387,7 @@ function generateCtInstance(context, recordNumber, data, index) {
   return {
     id: generateCtInstanceId(context, recordNumber, orderNumber),
     label: `${ctName} (Table ${doName}, Record ${recordNumber}, Column CT/${orderNumber})`,
-    type_of: ['CellTypeColumnInstance'],
+    type_of: ['CellTypeRecord'],
     ccf_pref_label: ctName,
     source_concept: generateIdWhenEmpty(id, ctName),
     record_number: recordNumber,
@@ -403,7 +403,7 @@ function generateBmInstance(context, recordNumber, data, index) {
   return {
     id: generateBmInstanceId(context, recordNumber, orderNumber),
     label: `${bmName} (Table ${doName}, Record ${recordNumber}, Column BM/${orderNumber})`,
-    type_of: ['BiomarkerColumnInstance'],
+    type_of: ['BiomarkerRecord'],
     ccf_pref_label: bmName,
     ccf_biomarker_type: b_type,
     source_concept: generateIdWhenEmpty(id, bmName),

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -370,7 +370,7 @@ function generateAsInstance(context, recordNumber, data, index) {
   return {
     id: generateAsInstanceId(context, recordNumber, orderNumber),
     label: `${asName} (${doName}-R${recordNumber}-AS${orderNumber})`,
-    type_of: [generateIdWhenEmpty(id, asName)],
+    type_of: ['AnatomicalStructureColumnInstance'],
     ccf_pref_label: asName,
     source_concept: generateIdWhenEmpty(id, asName),
     record_number: recordNumber,
@@ -386,7 +386,7 @@ function generateCtInstance(context, recordNumber, data, index) {
   return {
     id: generateCtInstanceId(context, recordNumber, orderNumber),
     label: `${ctName} (${doName}-R${recordNumber}-CT${orderNumber})`,
-    type_of: [generateIdWhenEmpty(id, ctName)],
+    type_of: ['CellTypeColumnInstance'],
     ccf_pref_label: ctName,
     source_concept: generateIdWhenEmpty(id, ctName),
     record_number: recordNumber,
@@ -402,7 +402,7 @@ function generateBmInstance(context, recordNumber, data, index) {
   return {
     id: generateBmInstanceId(context, recordNumber, orderNumber),
     label: `${bmName} (${doName}-R${recordNumber}-BM${orderNumber})`,
-    type_of: [generateIdWhenEmpty(id, bmName)],
+    type_of: ['BiomarkerColumnInstance'],
     ccf_pref_label: bmName,
     ccf_biomarker_type: b_type,
     source_concept: generateIdWhenEmpty(id, bmName),


### PR DESCRIPTION
tl;dr

### Slots that have been restored to their previous names.

Class: `AsctbRecord`
* as_records --> anatomical_structure_list
* ct_records --> cell_type_list
* bg_records --> gene_marker_list
* bp_records --> protein_marker_list
* bl_records --> lipid_marker_list
* bm_records --> metabolites_marker_list
* bf_records --> proteoforms_marker_list
* ref_records --> references

Class: `CellMarkerDescriptor`
* targeted_cell_type --> primary_cell_type
* cell_type_location --> primary_anatomical_structure
* characterizing_biomarkers --> biomarker_set

### Changes that do not impact production queries

* AnatomicalStructureInstance --> AnatomicalStructureColumnInstance
* CellTypeInstance --> CellTypeColumnInstance
* BiomarkerInstance --> BiomarkerColumnInstance
* Labels on the the column instances so they become less cryptic, e.g., 'Fallopian tube (fallopian-tube-R1-AS1)' -->  'Fallopian tube (Table fallopian-tube, Record 1, Column AS/1)'
