### PR TITLE
Adding title and descriptions for classes in LinkML schemas

### DIFF
--- a/schemas/src/digital-objects/2d-ftu.yaml
+++ b/schemas/src/digital-objects/2d-ftu.yaml
@@ -22,6 +22,11 @@ settings:
 
 classes:
   FtuIllustration:
+    title: FTU Illustration
+    description: >-
+      A two-dimensional illustration of an organ's functional tissue 
+      unit, featuring image assets and labeled nodes that highlight 
+      the constituent cell types.
     class_uri: ccf:FtuIllustration
     mixins:
       - Named
@@ -38,6 +43,8 @@ classes:
           partial_match: false
 
   FtuIllustrationFile:
+    title: FTU Illustration File
+    description: An image file that shows the functional tissue unit.
     class_uri: ccf:ImageFile
     mixins:
       - Named
@@ -47,6 +54,11 @@ classes:
       - file_format
 
   FtuIllustrationNode:
+    title: FTU Illustration Node
+    description: >-
+      A section of the illustration image representing a highlighted 
+      cell type, annotated with the corresponding Cell Ontology ID 
+      using the type_of relationship.
     class_uri: ccf:FtuIllustrationNode
     mixins:
       - Named
@@ -56,6 +68,8 @@ classes:
       - part_of_illustration
 
   FtuMetadata:
+    title: FTU Metadata
+    description: The metadata section for the "2d-ftu"" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -45,6 +45,11 @@ classes:
 
   AnatomicalStructure:
     is_a: AsctbConcept
+    title: Anatomical Structure
+    description: >-
+      An anatomical structure is a distinct biological entity, such as 
+      an organ or tissue with a defined form and function within an 
+      organism.
     slots:
       - ccf_part_of
     slot_usage:
@@ -58,6 +63,11 @@ classes:
 
   CellType:
     is_a: AsctbConcept
+    title: Cell Type
+    description: >-
+      A cell type is a distinct classification of cells defined by 
+      specific structural, functional, and molecular characteristics 
+      within an organism.
     slots:
       - ccf_ct_isa
       - ccf_located_in
@@ -91,6 +101,11 @@ classes:
 
   Biomarker:
     is_a: AsctbConcept
+    title: Biomarker
+    description: >-
+      A biomarker is a specific molecule or feature, such as a gene, 
+      protein, or surface marker, that uniquely identifies or 
+      distinguishes a particular cell type.
     slots:
       - ccf_biomarker_type
     slot_usage:
@@ -103,6 +118,10 @@ classes:
       owl: Class
 
   CharacterizingMarkerSet:
+    title: Characterizing Marker Set
+    description: >-
+      A characterizing marker set is a group of biomarkers used collectively 
+      to define and distinguish a specific cell type or state.
     slots:
       - members
       - references
@@ -111,6 +130,11 @@ classes:
         range: string
 
   AsctbRecord:
+    title: ASCT+B Record
+    description: >-
+      An ASCT+B record is a single row in the ASCT+B table that documents 
+      anatomical structures (AS), cell types (CT), and biomarkers (B), 
+      providing a structured representation of their relationships.
     mixins:
       - Named
       - Instance
@@ -131,6 +155,11 @@ classes:
           owl: AnnotationAssertion, AnnotationProperty
 
   AnatomicalStructureRecord:
+    title: Anatomical Structure Record
+    description: >-
+      An anatomical structure record represents a specific value 
+      in the ASCT+B table, located in the "AS" column, identified 
+      by its row (record number) and column (order number).
     mixins:
       - Named
       - Instance
@@ -141,6 +170,11 @@ classes:
       - order_number
 
   CellTypeRecord:
+    title: Cell Type Record
+    description: >-
+      An cell type record represents a specific value in the ASCT+B table, 
+      located in the "CT" column, identified by its row (record number) 
+      and column (order number).
     mixins:
       - Named
       - Instance
@@ -151,6 +185,11 @@ classes:
       - order_number
 
   BiomarkerRecord:
+    title: Biomarker Record
+    description: >-
+      An biomarker record represents a specific value in the ASCT+B table, 
+      located in the "B" column, identified by its row (record number) and 
+      column (order number).
     mixins:
       - Named
       - Instance
@@ -162,6 +201,11 @@ classes:
       - order_number
 
   CellMarkerDescriptor:
+    title: Cell Marker Descriptor
+    description: >-
+      A cell marker descriptor is study-derived information about a set 
+      of biomarkers used to identify a specific cell type within a particular 
+      tissue location, supported by associated scientific references.
     mixins:
       - Named
       - Instance
@@ -178,6 +222,8 @@ classes:
           owl: AnnotationAssertion, AnnotationProperty
 
   AsctbDataset:
+    title: ASCT+B Data
+    description: The data section for the "asct-b" digital object.
     slots:
       - anatomical_structures
       - cell_types
@@ -186,6 +232,8 @@ classes:
       - cell_marker_descriptor
 
   AsctbMetadata:
+    title: ASCT+B Metadata
+    description: The metadata section for the "asct-b" digital object.
     class_uri: dcat:Dataset
     slots:
       - title
@@ -226,13 +274,13 @@ classes:
 slots:
   anatomical_structures:
     title: anatomical structure data
-    description: List of anatomical structures referenced in the ASCT-B records.
+    description: List of anatomical structures referenced in the ASCT+B records.
     multivalued: true
     inlined_as_list: true
     range: AnatomicalStructure
   cell_types:
     title: cell type data
-    description: List of cell types referenced in the ASCT-B records.
+    description: List of cell types referenced in the ASCT+B records.
     multivalued: true
     inlined_as_list: true
     range: CellType
@@ -240,19 +288,19 @@ slots:
     title: biomarker data
     description: >-
       List of biomarkers (i.e., gene, protein, lipid, metabolites, proteoforms) 
-      referenced in the ASCT-B records.
+      referenced in the ASCT+B records.
     multivalued: true
     inlined_as_list: true
     range: Biomarker
   asctb_record:
     title: ASCT+B record
-    description: Records containing ASCT-B concepts and related data.
+    description: Records containing ASCT+B concepts and related data.
     multivalued: true
     inlined_as_list: true
     range: AsctbRecord
   cell_marker_descriptor:
     title: cell marker descriptor
-    description: Descriptors for cell markers within the ASCT-B dataset.
+    description: Descriptors for cell markers within the ASCT+B dataset.
     multivalued: true
     inlined_as_list: true
     range: CellMarkerDescriptor
@@ -271,12 +319,13 @@ slots:
     range: CharacterizingMarkerSet
     multivalued: true
   id:
-    title:
-    description: Unique identifier for ASCT-B concepts.
+    title: concept identifier
+    description: Unique identifier for ASCT+B concepts.
     required: true
     range: uriorcurie
     identifier: true
   label:
+    title: label
     description: Human-readable label or name for the concept.
     required: false
     slot_uri: rdfs:label
@@ -333,7 +382,7 @@ slots:
       owl: AnnotationAssertion, AnnotationProperty
   ccf_biomarker_type:
     title: biomarker type
-    description: Type of biomarker as per the ASCT-B specification.
+    description: Type of biomarker as per the ASCT+B specification.
     required: true
     slot_uri: ccf:ccf_biomarker_type
     annotations:
@@ -342,7 +391,7 @@ slots:
     title: source concept
     description: >-
       Source concept providing the origin of this record within the 
-      ASCT-B model.
+      ASCT+B model.
     required: true
     slot_uri: ccf:source_concept
     range: AsctbConcept
@@ -426,7 +475,7 @@ slots:
       owl: AnnotationAssertion, AnnotationProperty
   proteoforms_marker_list:
     title: proteoform marker
-    description: List of proteoforms markers referenced within ASCT-B records.
+    description: List of proteoforms markers referenced within ASCT+B records.
     required: false
     multivalued: true
     inlined_as_list: true

--- a/schemas/src/digital-objects/basic.yaml
+++ b/schemas/src/digital-objects/basic.yaml
@@ -13,6 +13,8 @@ imports:
 
 classes:
   BasicMetadata:
+    title: Basic Metadata
+    description: The metadata section for the "basic" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/collection.yaml
+++ b/schemas/src/digital-objects/collection.yaml
@@ -13,6 +13,8 @@ imports:
 
 classes:
   CollectionMetadata:
+    title: Collection Metadata
+    description: The metadata section for the "collection" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/ds-graph.yaml
+++ b/schemas/src/digital-objects/ds-graph.yaml
@@ -24,6 +24,8 @@ imports:
 
 classes:
   DatasetGraphData:
+    title: Dataset Graph Data
+    description: The data section for the "ds-graph" digital object.
     slots:
       - donor
       - sample
@@ -34,6 +36,8 @@ classes:
       - corridor
 
   DatasetGraphMetadata:
+    title: Dataset Graph Metadata
+    description: The metadadata section for the "ds-graph" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/graph.yaml
+++ b/schemas/src/digital-objects/graph.yaml
@@ -12,7 +12,9 @@ imports:
   - ../shared/metadata-base
 
 classes:
-  BasicMetadata:
+  GraphMetadata:
+    title: Graph Metadata
+    description: The metadata section for the "graph" digital object.
     class_uri: dcat:Dataset
     slots:
       - title
@@ -31,7 +33,7 @@ classes:
       iri:
         range: uriorcurie
       metadata:
-        range: BasicMetadata
+        range: GraphMetadata
       data:
         required: true
         multivalued: true

--- a/schemas/src/digital-objects/landmark.yaml
+++ b/schemas/src/digital-objects/landmark.yaml
@@ -23,6 +23,11 @@ settings:
 
 classes:
   SpatialEntity:
+    title: Spatial Entity
+    description: >-
+      A spatial entity is a defined object or structure with a specific 
+      location, boundary, and orientation in physical or conceptual 
+      space, such as an organ, tissue, or cell in anatomical studies.
     class_uri: ccf:SpatialEntity
     mixins:
       - Named
@@ -43,6 +48,11 @@ classes:
         pattern: (centimeter|millimeter)
 
   SpatialPlacement:
+    title: Spatial Placement
+    description: >-
+      Spatial placement refers to the positioning and orientation of 
+      an entity within a defined space or context, often describing 
+      its location relative to other entities or a coordinate system.
     class_uri: ccf:SpatialPlacement
     mixins:
       - Named
@@ -74,6 +84,11 @@ classes:
         pattern: (centimeter|millimeter)
 
   ExtractionSet:
+    title: Extraction Set
+    description: >-
+      An extraction set is a curated collection of specific data or 
+      items extracted from a specific source, often  based on specific 
+      locations or features, for targeted analysis or integration.
     class_uri: ccf:ExtractionSet
     mixins:
       - Named
@@ -84,11 +99,15 @@ classes:
       - rui_rank
 
   LandmarkData:
+    title: Landmark Data
+    description: The data section for the "landmark" digital object.
     slots:
       - landmarks
       - spatial_entities
 
   LandmarkMetadata:
+    title: Landmark Metadata
+    description: The metadata section for the "landmark" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/omap.yaml
+++ b/schemas/src/digital-objects/omap.yaml
@@ -23,6 +23,12 @@ settings:
 
 classes:
   Antibody:
+    title: Antibody
+    description: >-
+      An antibody is a protein produced by the immune system or engineered 
+      in the lab that specifically binds to a target molecule, such as a 
+      protein or antigen on a cell, and is widely used for identifying, 
+      labeling, or isolating specific cell types or biomarkers.
     slots:
       - id
       - parent_class
@@ -68,6 +74,12 @@ classes:
         {% endfor %}
 
   Protein:
+    title: Protein
+    description: >-
+       a protein is a biological macromolecule composed of amino 
+       acids that performs essential functions, such as providing 
+       structure, facilitating biochemical reactions (enzymes), 
+       signaling, transport, and regulating cellular processes.
     slots:
       - id
     slot_usage:
@@ -78,16 +90,32 @@ classes:
           partial_match: false
 
   DetectStatement:
+    title: Detect Statement
+    description: >-
+      A description of an antibody that identifies and binds 
+      specifically to a target protein.
     slots:
       - protein_id
       - rationale
 
   BindsToStatement:
+    title: Binds-to Statement
+    description: >-
+      A description of an antibody that binds specifically to a 
+      secondary antibody, typically as part of a detection or 
+      amplification process in experimental assays.
     slots:
       - antibody_id
       - rationale
 
   ExperimentUsedAntibody:
+    title: Experiment-used Antibody
+    description: >-
+      An experiment-used antibody is a detailed record of an antibody 
+      utilized in a specific experiment, including information about 
+      its concentration and dilution, the cycle or stage in which it 
+      was applied, the experiment where it was used, and the primary 
+      antibody it is derived from or based on.
     class_uri: ccf:ExperimentUsedAntibody
     mixins:
       - Named
@@ -101,6 +129,11 @@ classes:
       - based_on
 
   RegisteredAntibody:
+    title: Registered Antibody
+    description: >-
+      A registered antibody is an antibody with documented information, 
+      including its factory-assigned lot number, ensuring traceability 
+      and consistency for use in experiments or applications.
     mixins:
       - Named
       - Instance
@@ -108,6 +141,12 @@ classes:
       - lot_number
 
   MultiplexedAntibodyBasedImagingExperiment:
+    title: Mutliplexed Antibody-based Imaging Experiment
+    description: >-
+      A Multiplexed Antibody-based Imaging Experiment is a technique that 
+      uses multiple antibodies, each tagged with distinct markers or labels,
+      to simultaneously visualize and analyze multiple proteins or biomarkers 
+      within a single sample.
     class_uri: ccf:MultiplexedAntibodyBasedImagingExperiment
     mixins:
       - Named
@@ -132,6 +171,11 @@ classes:
           partial_match: false
 
   ExperimentCycle:
+    title: Experiment Cycle
+    description: >-
+      An experiment cycle refers to a single round of staining, imaging, 
+      and data acquisition for a specific set of antibodies, repeated 
+      iteratively to detect multiple targets within the same sample.
     class_uri: ccf:ExperimentCycle
     mixins:
       - Named
@@ -141,6 +185,12 @@ classes:
       - uses_antibodies
 
   AntibodyPanel:
+    title: Antibody Panel
+    description: >-
+      An antibody panel is a curated set of antibodies selected for a 
+      specific experiment or analysis, designed to target multiple 
+      proteins or biomarkers of interest simultaneously, often in 
+      multiplexed assays or imaging studies.
     class_uri: ccf:AntibodyPanel
     mixins:
       - Named
@@ -159,6 +209,8 @@ classes:
           partial_match: false
 
   OmapDataset:
+    title: OMAP Data
+    description: The data section for the "omap" digital object.
     slots:
       - antibody
       - experiment
@@ -166,6 +218,8 @@ classes:
       - antibody_panel
 
   OmapMetadata:
+    title: OMAP Metadata
+    description: The metadata section for the "omap" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/ref-organ.yaml
+++ b/schemas/src/digital-objects/ref-organ.yaml
@@ -25,6 +25,11 @@ settings:
 
 classes:
   SpatialEntity:
+    title: Spatial Entity
+    description: >-
+      A spatial entity is a defined object or structure with a specific 
+      location, boundary, and orientation in physical or conceptual 
+      space, such as an organ, tissue, or cell in anatomical studies.
     class_uri: ccf:SpatialEntity
     mixins:
       - Named
@@ -54,6 +59,11 @@ classes:
         pattern: (Left|Right)
 
   ExtractionSet:
+    title: Extraction Set
+    description: >-
+      An extraction set is a curated collection of specific data or 
+      items extracted from a specific source, often  based on specific 
+      locations or features, for targeted analysis or integration.
     class_uri: ccf:ExtractionSet
     mixins:
       - Named
@@ -73,6 +83,8 @@ classes:
           partial_match: false
 
   RefOrganMetadata:
+    title: Reference Organ Metadata
+    description: The metadata section for the "ref-organ" digital object.
     class_uri: dcat:Dataset
     slots:
       - title

--- a/schemas/src/digital-objects/vocab.yaml
+++ b/schemas/src/digital-objects/vocab.yaml
@@ -12,7 +12,9 @@ imports:
   - ../shared/metadata-base
 
 classes:
-  BasicMetadata:
+  VocabMetadata:
+    title: Vocabulary Metadata
+    description: The metadata section for the "vocab" digital object.
     class_uri: dcat:Dataset
     slots:
       - title
@@ -31,7 +33,7 @@ classes:
       iri:
         range: uriorcurie
       metadata:
-        range: BasicMetadata
+        range: VocabMetadata
       data:
         required: true
         multivalued: true

--- a/schemas/src/modules/cell-summary.yaml
+++ b/schemas/src/modules/cell-summary.yaml
@@ -17,6 +17,12 @@ imports:
 
 classes:
   CellSummary:
+    title: Cell Summary
+    description: >-
+      A cell summary is a detailed overview of cell-related data, including 
+      the annotation method used, summary rows with cell types and their 
+      counts, the modality (e.g., scRNA-seq), aggregated summaries of 
+      findings, and contextual information such as the donor tissue's sex.
     class_uri: ccf:CellSummary
     mixins:
       - Named
@@ -29,6 +35,12 @@ classes:
       - summary_rows
   
   CellSummaryRow:
+    title: Cell Summary Row
+    description: >-
+      A cell summary row is a single entry in a cell summary table that 
+      provides information about a specific cell type, including its name, 
+      count, and any related attributes such as tissue, modality, or donor 
+      characteristics.
     class_uri: ccf:CellSummaryRow
     mixins:
       - Named
@@ -41,6 +53,12 @@ classes:
       - percentage
 
   GeneExpression:
+    title: Gene Expression
+    description: >-
+      Gene expression refers to data that captures the activity levels of 
+      specific genes within a summarized cell population, including details 
+      like gene ID, label, Ensembl ID, and the mean expression value across 
+      the cells.
     class_uri: ccf:GeneExpression
     mixins:
      - Named

--- a/schemas/src/modules/collision.yaml
+++ b/schemas/src/modules/collision.yaml
@@ -17,6 +17,11 @@ imports:
 
 classes:
   CollisionSummary:
+    title: Collision Summary
+    description: >-
+      A collision summary provides an overview of detected collisions, 
+      including the method used for collision detection and details 
+      about the specific collision items identified.
     class_uri: ccf:CollisionSummary
     mixins:
       - Named
@@ -26,6 +31,12 @@ classes:
       - collision_items
   
   CollisionItem:
+    title: Collision Item
+    description: >-
+      A collision item is a detailed record of a spatial overlap, including 
+      information about the spatial entity involved, the volume of the 
+      collision, and the percentage of overlap relative to the entity's 
+      total volume.
     class_uri: ccf:CollisionItem
     mixins:
       - Named

--- a/schemas/src/modules/corridor.yaml
+++ b/schemas/src/modules/corridor.yaml
@@ -17,6 +17,12 @@ imports:
 
 classes:
   Corridor:
+    title: Corridor
+    description: >-
+      A corridor is a spatial data representation or model, often used 
+      to describe pathways or regions of interest in a given space. 
+      It includes details about the file format and the file URL for 
+      accessing the data.
     class_uri: ccf:Corridor
     mixins:
       - Named

--- a/schemas/src/modules/dataset.yaml
+++ b/schemas/src/modules/dataset.yaml
@@ -17,6 +17,13 @@ imports:
 
 classes:
   AssayDataset:
+    title: Assay Dataset
+    description: >-
+      An assay dataset is a collection of data generated from a specific 
+      experimental assay, providing details about the description of 
+      the dataset, the technology or methodology used, and the 
+      associated cell summaries that outline the analyzed cell types a
+      nd their attributes.
     class_uri: ccf:Dataset
     mixins:
       - Named

--- a/schemas/src/modules/donor.yaml
+++ b/schemas/src/modules/donor.yaml
@@ -17,6 +17,12 @@ imports:
 
 classes:
   Donor:
+    title: Donor
+    description: >-
+      A donor refers to an individual from whom biological samples or 
+      data are obtained for research, with associated information 
+      including age, BMI, sex, race, the providers supplying the sample, 
+      and the consortium responsible for its collection.
     class_uri: ccf:Donor
     mixins:
       - Named

--- a/schemas/src/modules/sample.yaml
+++ b/schemas/src/modules/sample.yaml
@@ -17,6 +17,13 @@ imports:
 
 classes:
   TissueBlock:
+    title: Tissue Block
+    description: >-
+      A tissue block is a defined piece of tissue extracted from a 
+      specific location for research or analysis, with detailed 
+      information about its extraction site, tissue sections, 
+      associated datasets, section counts and sizes, and collision 
+      summaries related to spatial overlaps.
     class_uri: ccf:TissueBlock
     mixins:
       - Named
@@ -45,6 +52,11 @@ classes:
             {% endfor %}
 
   TissueSection:
+    title: Tissue Section
+    description: >-
+      A tissue section is a thin slice or layer derived from a tissue block, 
+      associated with a specific section number, and linked to datasets 
+      generated from its analysis. 
     class_uri: ccf:TissueSection
     mixins:
       - Named

--- a/schemas/src/modules/spatial.yaml
+++ b/schemas/src/modules/spatial.yaml
@@ -17,6 +17,11 @@ imports:
 
 classes:
   SpatialEntity:
+    title: Spatial Entity
+    description: >-
+      A spatial entity is a defined object or structure with a specific 
+      location, boundary, and orientation in physical or conceptual 
+      space, such as an organ, tissue, or cell in anatomical studies.
     class_uri: ccf:SpatialEntity
     mixins:
       - Named
@@ -38,6 +43,11 @@ classes:
         pattern: (centimeter|millimeter)
 
   SpatialPlacement:
+    title: Spatial Placement
+    description: >-
+      Spatial placement refers to the positioning and orientation of 
+      an entity within a defined space or context, often describing 
+      its location relative to other entities or a coordinate system.
     class_uri: ccf:SpatialPlacement
     mixins:
       - Named
@@ -70,6 +80,11 @@ classes:
         pattern: (centimeter|millimeter)
 
   SpatialObjectReference:
+    title: Spatial Object Reference
+    description: >-
+      A spatial object reference is a record describing a spatial entity, 
+      including its placement within a defined space, the associated file 
+      name, URL for access, and file format.
     class_uri: ccf:SpatialObjectReference
     mixins:
       - Named


### PR DESCRIPTION
This will show the definition of an object as an instance of a class when hovering over the entire object.

![Screenshot 2024-11-22 at 2 55 45 PM](https://github.com/user-attachments/assets/dff3c882-5694-4fa9-ad44-5f6c80c3df73)
