### PR TITLE
Replace uriorcurie type with an entity concept ID

### DIFF
--- a/schemas/src/digital-objects/2d-ftu.yaml
+++ b/schemas/src/digital-objects/2d-ftu.yaml
@@ -35,12 +35,6 @@ classes:
       - located_in
       - image_file
       - illustration_node
-    slot_usage:
-      located_in:
-        structured_pattern:
-          syntax: "({uberon}|{fma}):\\d+"
-          interpolated: true
-          partial_match: false
 
   FtuIllustrationFile:
     title: FTU Illustration File
@@ -66,6 +60,17 @@ classes:
     slots:
       - node_name
       - part_of_illustration
+
+  AnatomicalStructureID:
+    title: Anatomical Structure Identifier
+    slots:
+      - id
+    slot_usage:
+      id:
+        structured_pattern:
+          syntax: "({uberon}|{fma}):\\d+"
+          interpolated: true
+          partial_match: false
 
   FtuMetadata:
     title: FTU Metadata
@@ -113,7 +118,7 @@ slots:
     title: located in
     description: Specifies the anatomical location of a cell type.
     slot_uri: ccf:ccf_located_in
-    range: uriorcurie
+    range: AnatomicalStructureID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   image_file:

--- a/schemas/src/digital-objects/landmark.yaml
+++ b/schemas/src/digital-objects/landmark.yaml
@@ -182,7 +182,7 @@ slots:
     title: extraction set
     description: Reference to an extraction set.
     required: true
-    range: uriorcurie
+    range: ExtractionSet
     inlined: false
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
@@ -191,7 +191,7 @@ slots:
     description: >-
       Reference to the spatial entity associated with the extraction set.
     required: true
-    range: uriorcurie
+    range: SpatialEntity
     inlined: false
     annotations:
       owl: AnnotationProperty, AnnotationAssertion

--- a/schemas/src/digital-objects/omap.yaml
+++ b/schemas/src/digital-objects/omap.yaml
@@ -317,7 +317,7 @@ slots:
     title: is used by experiment
     description: References to the experiment where the antibody was used.
     required: true
-    range: uriorcurie
+    range: MultiplexedAntibodyBasedImagingExperiment
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   conjugate:
@@ -374,11 +374,11 @@ slots:
       owl: AnnotationProperty, AnnotationAssertion
   has_cycle:
     title: has cycle
-    description: >- 
+    description: >-
       A reference to the experimental cycles within which the antibody
       was used.
     required: true
-    range: uriorcurie
+    range: ExperimentCycle
     multivalued: true
     inlined_as_list: false
     annotations:

--- a/schemas/src/modules/cell-summary.yaml
+++ b/schemas/src/modules/cell-summary.yaml
@@ -2,11 +2,16 @@ id: https://purl.humanatlas.io/specs/cell-summary
 name: cell-summary
 prefixes:
   ccf: http://purl.org/ccf/
+  ASCTB-TEMP: https://purl.org/ccf/ASCTB-TEMP_
   oboInOwl: http://www.geneontology.org/formats/oboInOwl#
   loinc: http://purl.bioontology.org/ontology/LNC/
   linkml: https://w3id.org/linkml/
+  CL: http://purl.obolibrary.org/obo/CL_
+  PCL: http://purl.obolibrary.org/obo/PCL_
   RO: http://purl.obolibrary.org/obo/RO_
   IAO: http://purl.obolibrary.org/obo/IAO_
+  HGNC: http://identifiers.org/hgnc/
+  ensembl: https://identifiers.org/ensembl/
 
 default_prefix: ccf
 default_range: string
@@ -14,6 +19,12 @@ default_range: string
 imports:
   - linkml:types
   - ../shared/metadata-base
+
+settings:
+  cl: "CL"
+  pcl: "PCL"
+  asctb_temp: "ASCTB-TEMP"
+  hgnc: "HGNC"
 
 classes:
   CellSummary:
@@ -52,6 +63,17 @@ classes:
       - count
       - percentage
 
+  CellID:
+    title: Cell Identifier
+    slots:
+      - id
+    slot_usage:
+      id:
+        structured_pattern:
+          syntax: "({cl}|{pcl}):\\d+|{asctb_temp}:[a-zA-Z0-9-]+"
+          interpolated: true
+          partial_match: false
+
   GeneExpression:
     title: Gene Expression
     description: >-
@@ -68,6 +90,17 @@ classes:
      - gene_label
      - ensembl_id
      - mean_gene_expression_value
+
+  GeneID:
+    title: Gene Identifier
+    slots:
+      - id
+    slot_usage:
+      id:
+        structured_pattern:
+          syntax: "{hgnc}:\\d{1,5}"
+          interpolated: true
+          partial_match: false
 
   CellSummaryData:
     attributes:
@@ -160,7 +193,7 @@ slots:
     title: cell type identifier
     description: Unique identifier assigned to a cell type.
     required: true
-    range: uriorcurie
+    range: CellID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   cell_label:
@@ -199,7 +232,7 @@ slots:
     title: gene identifier
     description: Unique identifier assigned to a gene symbol.
     required: true
-    range: uriorcurie
+    range: GeneID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   gene_label:

--- a/schemas/src/modules/collision.yaml
+++ b/schemas/src/modules/collision.yaml
@@ -46,6 +46,11 @@ classes:
       - volume
       - percentage
 
+  SpatialEntityID:
+    title: Spatial Entity Identifier
+    slots:
+      - id
+
   CollisionData:
     attributes:
       donor:
@@ -132,7 +137,7 @@ slots:
     description: Reference to the spatial entity involved in the collision.
     slot_uri: ccf:has_spatial_entity
     required: true
-    range: uriorcurie
+    range: SpatialEntityID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   volume:

--- a/schemas/src/modules/dataset.yaml
+++ b/schemas/src/modules/dataset.yaml
@@ -36,6 +36,16 @@ classes:
       - thumbnail
       - cell_summaries
       - links_back_to
+
+  CellSummaryID:
+    title: Cell Summary Identifier
+    slots:
+      - id
+
+  SampleID:
+    title: Sample Identifier
+    slots:
+      - id
   
   AssayDatasetData:
     attributes:
@@ -92,7 +102,7 @@ slots:
     slot_uri: ccf:has_cell_summary
     required: false
     multivalued: true
-    range: uriorcurie
+    range: CellSummaryID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   links_back_to:
@@ -100,7 +110,7 @@ slots:
     description: >-
       URI that links back to a related resource as a reference connection.
     required: false
-    range: uriorcurie
+    range: SampleID
     annotations:
       owl: ObjectProperty, ObjectPropertyAssertion
       owl.template: |-

--- a/schemas/src/modules/donor.yaml
+++ b/schemas/src/modules/donor.yaml
@@ -69,6 +69,11 @@ classes:
       race_id:
         pattern: (loinc:LA10608-0|loinc:LA6156-9|loinc:LA10610-6|loinc:LA10611-4|loinc:LA4457-3|loinc:LA4489-6)
 
+  SampleID:
+    title: Sample Identifier
+    slots:
+      - id
+
   DonorData:
     attributes:
       donor:
@@ -164,6 +169,6 @@ slots:
     slot_uri: ccf:provides
     multivalued: true
     inlined: false
-    range: uriorcurie
+    range: SampleID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion

--- a/schemas/src/modules/sample.yaml
+++ b/schemas/src/modules/sample.yaml
@@ -70,6 +70,26 @@ classes:
       - section_number
       - links_back_to
 
+  SpatialEntityID:
+    title: Spatial Entity Identifier
+    slots:
+      - id
+
+  CollisionSummaryID:
+    title: Collision Summary Identifier
+    slots:
+      - id
+
+  CorridorID:
+    title: Corridor Identifier
+    slots:
+      - id
+
+  SampleOrDonorID:
+    title: Sample or Donor Identifier
+    slots:
+      - id
+
   SampleData:
     attributes:
       donor:
@@ -131,7 +151,7 @@ slots:
       the reference atlas.
     slot_uri: ccf:has_registration_location
     required: false
-    range: uriorcurie
+    range: SpatialEntityID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   extraction_site:
@@ -140,7 +160,7 @@ slots:
       Reference to the anatomical site from which the tissue was extracted.
     slot_uri: ccf:has_extraction_site
     required: false
-    range: uriorcurie
+    range: SpatialEntityID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   sections:
@@ -195,7 +215,7 @@ slots:
     slot_uri: ccf:has_collision_summary
     required: false
     multivalued: true
-    range: uriorcurie
+    range: CollisionSummaryID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   corridors:
@@ -206,7 +226,7 @@ slots:
     slot_uri: ccf:has_corridor
     required: false
     multivalued: true
-    range: uriorcurie
+    range: CorridorID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   links_back_to:
@@ -214,7 +234,7 @@ slots:
     description: >-
       URI that links back to a related resource as a reference connection.
     required: false
-    range: uriorcurie
+    range: SampleOrDonorID
     annotations:
       owl: ObjectProperty, ObjectPropertyAssertion
       owl.template: |-

--- a/schemas/src/modules/spatial.yaml
+++ b/schemas/src/modules/spatial.yaml
@@ -7,6 +7,9 @@ prefixes:
   linkml: https://w3id.org/linkml/
   RO: http://purl.obolibrary.org/obo/RO_
   IAO: http://purl.obolibrary.org/obo/IAO_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  FMA: http://purl.org/sig/ont/fma/fma
+  ASCTB-TEMP: https://purl.org/ccf/ASCTB-TEMP_
 
 default_prefix: ccf
 default_range: string
@@ -14,6 +17,11 @@ default_range: string
 imports:
   - linkml:types
   - ../shared/metadata-base
+
+settings:
+  uberon: "UBERON"
+  fma: "FMA"
+  asctb_temp: "ASCTB-TEMP"
 
 classes:
   SpatialEntity:
@@ -96,6 +104,17 @@ classes:
       - file_format
       - placement
 
+  AnatomicalStructureID:
+    title: Anatomical Structure Identifier
+    slots:
+      - id
+    slot_usage:
+      id:
+        structured_pattern:
+          syntax: "({uberon}|{fma}):\\d+|{asctb_temp}[a-zA-Z0-9-]+"
+          interpolated: true
+          partial_match: false
+
   SpatialData:
     attributes:
       donor:
@@ -160,7 +179,7 @@ slots:
       Identifies other anatomical structures that intersect or collide with
       this spatial entity.
     multivalued: true
-    range: uriorcurie
+    range: AnatomicalStructureID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   slice_count:
@@ -197,7 +216,7 @@ slots:
     description: The spatial entity relative to which the placement is defined.
     slot_uri: ccf:placement_relative_to
     required: true
-    range: uriorcurie
+    range: SpatialEntity
     annotations:
       owl: AnnotationProperty, AnnotationAssertion
   source:

--- a/src/normalization/normalize-ds-graph.js
+++ b/src/normalization/normalize-ds-graph.js
@@ -126,7 +126,7 @@ function createTissueBlockObject(context, donor, block) {
     .append('section_count', block.section_count)
     .append('section_size', block.section_size)
     .append('section_size_unit', block.section_size_unit)
-    .append('collision_summaries', block.rui_location?.['all_collisions'].map((collision, index) => 
+    .append('collision_summaries', block.rui_location?.['all_collisions']?.map((collision, index) =>
       generateCollisionId(context, block, collision, index)).filter(onlyNonNull) || [])
     .append('corridors', getCorridorId(context, block))
     .append('links_back_to', checkDonorId(donor['@id']))
@@ -264,7 +264,7 @@ function normalizeCellSummaryData(context, data) {
   const sampleBlockCellSummaries = donors.map((donor) => {
     return donor['samples'].map((block) => {
       return block['datasets']?.map((dataset) => {
-        return dataset['summaries']?.map((summary, index) => 
+        return dataset['summaries']?.map((summary, index) =>
           createCellSummaryObject(context, dataset, summary, index))
       }).flat();
     }).flat();
@@ -273,7 +273,7 @@ function normalizeCellSummaryData(context, data) {
     return donor['samples'].map((block) => {
       return block['sections']?.map((section) => {
         return section['datasets']?.map((dataset) => {
-          return dataset['summaries']?.map((summary, index) => 
+          return dataset['summaries']?.map((summary, index) =>
             createCellSummaryObject(context, dataset, summary, index))
         }).flat();
       }).flat();
@@ -302,7 +302,7 @@ function createCellSummaryRowObject(context, dataset, summary, summaryRow, index
     .append('type_of', ['CellSummaryRow'])
     .append('cell_id', summaryRow.cell_id)
     .append('cell_label', summaryRow.cell_label)
-    .append('gene_expressions', summaryRow['gene_expr']?.map((expr, itemIndex) => 
+    .append('gene_expressions', summaryRow['gene_expr']?.map((expr, itemIndex) =>
       createGeneExpressionObject(context, dataset, summary, summaryRow, expr, itemIndex)) || [])
     .append('count', summaryRow.count)
     .append('percentage', summaryRow.percentage)
@@ -318,7 +318,7 @@ function createGeneExpressionObject(context, dataset, summary, summaryRow, expr,
     .append('gene_label', expr.gene_label)
     .append('ensembl_id', expr.ensembl_id)
     .append('mean_gene_expression_value', expr.mean_gene_expr_value)
-    .build();  
+    .build();
 }
 
 // ---------------------------------------------------------------------------------
@@ -333,7 +333,7 @@ function normalizeCollisionData(context, data) {
         createCollisionObject(context, block, collision, index)
       ).filter(onlyNonNull) || []
     }).flat();
-  }).flat();  
+  }).flat();
 }
 
 function createCollisionObject(context, block, collision, index) {
@@ -346,9 +346,9 @@ function createCollisionObject(context, block, collision, index) {
     .append('label', getCollisionLabel(block, collision, index))
     .append('type_of', ['CollisionSummary'])
     .append('collision_method', collision.collision_method)
-    .append('collision_items', collision['collisions']?.map((collisionItem, itemIndex) => 
+    .append('collision_items', collision['collisions']?.map((collisionItem, itemIndex) =>
       createCollisionItemObject(context, block, collision, collisionItem, itemIndex)) || [])
-    .build();  
+    .build();
 }
 
 function createCollisionItemObject(context, block, collision, collisionItem, index) {
@@ -359,7 +359,7 @@ function createCollisionItemObject(context, block, collision, collisionItem, ind
     .append('spatial_entity_reference', collisionItem.as_3d_id)
     .append('volume', collisionItem.as_volume)
     .append('percentage', collisionItem.percentage)
-    .build();  
+    .build();
 }
 
 // ---------------------------------------------------------------------------------
@@ -373,7 +373,7 @@ function normalizeCorridorData(context, data) {
       const corridor = block['rui_location']['corridor'];
       return corridor ? createCorridorObject(context, block, corridor) : null;
     }).filter(onlyNonNull);
-  }).flat();  
+  }).flat();
 }
 
 function createCorridorObject(context, block, corridor) {
@@ -383,7 +383,7 @@ function createCorridorObject(context, block, corridor) {
     .append('type_of', ['Corridor'])
     .append('file_format', corridor.file_format)
     .append('file_url', corridor.file)
-    .build();   
+    .build();
 }
 
 // ---------------------------------------------------------------------------------
@@ -411,7 +411,7 @@ function getCorridorId(context, block) {
 function generateCorridorId(context, block, corridor) {
   const { iri, version } = context.selectedDigitalObject;
   const hashCode = getCorridorHash(block, corridor);
-  return `${iri}/${version}#${hashCode}`;  
+  return `${iri}/${version}#${hashCode}`;
 }
 
 function generateCollisionId(context, block, collision, index) {
@@ -420,13 +420,13 @@ function generateCollisionId(context, block, collision, index) {
   }
   const { iri, version } = context.selectedDigitalObject;
   const hashCode = getCollisionHash(block, collision, index);
-  return `${iri}/${version}#${hashCode}`;  
+  return `${iri}/${version}#${hashCode}`;
 }
 
 function generateCollisionItemId(context, block, collision, collisionItem, index) {
   const { iri, version } = context.selectedDigitalObject;
   const hashCode = getCollisionItemHash(block, collision, collisionItem, index);
-  return `${iri}/${version}#${hashCode}`;  
+  return `${iri}/${version}#${hashCode}`;
 }
 
 function generateCellSummaryId(context, dataset, summary, index) {
@@ -484,7 +484,7 @@ function getCollisionItemHash(block, collision, collisionItem, index, length=0) 
 function getCorridorHash(block, corridor, length=0) {
   const { file } = corridor;
   const primaryKey = `${block['@id']}-${file}`;
-  return getHashCode(primaryKey, length);  
+  return getHashCode(primaryKey, length);
 }
 
 function getHashCode(str, length=0) {
@@ -550,7 +550,7 @@ function getCollisionItemLabel(block, collision, collisionItem, index) {
 
 function getCorridorLabel(block, collision) {
   const hashCode = getCorridorHash(block, collision, 5);
-  return `Corridor of tissue block (#${hashCode})`; 
+  return `Corridor of tissue block (#${hashCode})`;
 }
 
 function getSexId(sex) {

--- a/src/utils/logging.js
+++ b/src/utils/logging.js
@@ -10,8 +10,8 @@ export function banner(title) {
 export function header(context, pipeline) {
   const { type, name, version, iri } = context.selectedDigitalObject;
   info('');
-  info(chalk.whiteBright('---') + ' ' + 
-       chalk.green(`${type}:${version}:${name}`) + ' ' + 
+  info(chalk.whiteBright('---') + ' ' +
+       chalk.green(`${type}:${version}:${name}`) + ' ' +
        chalk.whiteBright(`(${pipeline})`) + ' @ ' +
        chalk.cyanBright(iri) + ' ' +
        chalk.whiteBright('---'));
@@ -27,6 +27,7 @@ export function warning(message) {
 
 export function error(message) {
   console.log('[' + chalk.redBright('ERROR') + '] ' + chalk.redBright(message));
+  console.log(message);
 }
 
 export function more(message) {


### PR DESCRIPTION
This replacement will make sure identifiers will be converted to IRI instead of string during the OWL conversion.