### PR TITLE
Extracting references from description text in metadata.yaml file

### DIFF
--- a/schemas/src/shared/metadata-base.yaml
+++ b/schemas/src/shared/metadata-base.yaml
@@ -98,6 +98,7 @@ classes:
       - project_leads
       - externalReviewers
       - distributions
+      - references
 
 slots:
   # DCAT properties

--- a/src/finalizing/templates/readme-md.njk
+++ b/src/finalizing/templates/readme-md.njk
@@ -88,6 +88,13 @@
 {{ was_derived_from.doi }}
 {% endif %}
 
+{% if 'references' in was_derived_from %}
+**References:**
+{% for reference in was_derived_from.references %}
+* [{{ reference }}]({{ reference }})
+{% endfor %}
+{% endif %}
+
 **Downloads:**
 {% for distribution in was_derived_from.distributions %}
 * [{{ distribution.title }}]({{ distribution.downloadUrl }})

--- a/src/finalizing/utils/generate-index-html.js
+++ b/src/finalizing/utils/generate-index-html.js
@@ -57,6 +57,7 @@ function getStructuredData(context, metadata) {
         name: funder.funder,
       })),
       citation: was_derived_from.citation,
+      references: was_derived_from.references,
       includedInDataCatalog: {
         '@type': 'DataCatalog',
         '@id': `${context.purlIri}${type}/${name}`,

--- a/src/normalization/reference-extractor/biorxiv-extractor.js
+++ b/src/normalization/reference-extractor/biorxiv-extractor.js
@@ -1,0 +1,40 @@
+class BioRxivExtractor {
+  /**
+   * Extracts bioRxiv references from text
+   * 
+   * @param {string} text - Text to extract from
+   * @returns {string[]} - Array of bioRxiv IRIs
+   */
+  extract(text) {
+    const references = [];
+    
+    // Pattern for bioRxiv URLs
+    const biorxivUrlPattern = /https?:\/\/www\.biorxiv\.org\/content\/[^\s\)\]>]+/g;
+    let match;
+    
+    while ((match = biorxivUrlPattern.exec(text)) !== null) {
+      references.push(this.cleanUrl(match[0]));
+    }
+    
+    // Pattern for bare bioRxiv IDs
+    const bareBiorxivPattern = /\bbioRxiv:([^\s\)\]>]+)/g;
+    
+    while ((match = bareBiorxivPattern.exec(text)) !== null) {
+      references.push(`https://www.biorxiv.org/content/${match[1]}`);
+    }
+    
+    return references;
+  }
+  
+  /**
+   * Cleans a URL by removing trailing punctuation and non-URL characters
+   * 
+   * @param {string} url - The URL to clean
+   * @returns {string} - The cleaned URL
+   */
+  cleanUrl(url) {
+    return url.replace(/[.,;:)\]]+$/, '');
+  }
+}
+
+export { BioRxivExtractor };

--- a/src/normalization/reference-extractor/biorxiv-extractor.js
+++ b/src/normalization/reference-extractor/biorxiv-extractor.js
@@ -9,7 +9,7 @@ class BioRxivExtractor {
     const references = [];
     
     // Pattern for bioRxiv URLs
-    const biorxivUrlPattern = /https?:\/\/www\.biorxiv\.org\/content\/[^\s\)\]>]+/g;
+    const biorxivUrlPattern = /https?:\/\/(www\.)?biorxiv\.org\/content\/[^\s\)\]>]+/g;
     let match;
     
     while ((match = biorxivUrlPattern.exec(text)) !== null) {

--- a/src/normalization/reference-extractor/doi-extractor.js
+++ b/src/normalization/reference-extractor/doi-extractor.js
@@ -1,0 +1,40 @@
+class DOIExtractor {
+  /**
+   * Extracts DOI references from text
+   * 
+   * @param {string} text - Text to extract from
+   * @returns {string[]} - Array of DOI IRIs
+   */
+  extract(text) {
+    const references = [];
+    
+    // Pattern for DOI URLs (https://doi.org/...)
+    const doiUrlPattern = /https?:\/\/doi\.org\/[^\s\)\]>]+/g;
+    let match;
+    
+    while ((match = doiUrlPattern.exec(text)) !== null) {
+      references.push(this.cleanUrl(match[0]));
+    }
+    
+    // Pattern for bare DOIs (doi:10.xxxx/yyyy or DOI: 10.xxxx/yyyy)
+    const bareDoiPattern = /\b(?:doi:?|DOI:?)\s*(10\.[^\s\)\]>]+)/g;
+    
+    while ((match = bareDoiPattern.exec(text)) !== null) {
+      references.push(`https://doi.org/${match[1]}`);
+    }
+    
+    return references;
+  }
+  
+  /**
+   * Cleans a URL by removing trailing punctuation and non-URL characters
+   * 
+   * @param {string} url - The URL to clean
+   * @returns {string} - The cleaned URL
+   */
+  cleanUrl(url) {
+    return url.replace(/[.,;:)\]]+$/, '');
+  }
+}
+
+export { DOIExtractor };

--- a/src/normalization/reference-extractor/reference-extractor.js
+++ b/src/normalization/reference-extractor/reference-extractor.js
@@ -1,0 +1,72 @@
+class ReferenceExtractor {
+  constructor() {
+    // Registry of extraction strategies
+    this.strategies = new Map();
+  }
+  
+  /**
+   * Registers a new extraction strategy
+   * 
+   * @param {string} name - Unique identifier for the strategy
+   * @param {Object} strategy - Strategy object with extract() method
+   * @returns {ReferenceExtractor} - Returns this for method chaining
+   */
+  registerStrategy(name, strategy) {
+    if (typeof strategy.extract !== 'function') {
+      throw new Error('Strategy must implement extract() method');
+    }
+    this.strategies.set(name, strategy);
+    return this;
+  }
+  
+  /**
+   * Removes a strategy from the registry
+   * 
+   * @param {string} name - Strategy identifier to remove
+   * @returns {boolean} - True if strategy was removed, false if not found
+   */
+  unregisterStrategy(name) {
+    return this.strategies.delete(name);
+  }
+  
+  /**
+   * Gets a list of all registered strategy names
+   * 
+   * @returns {string[]} - Array of strategy names
+   */
+  getRegisteredStrategies() {
+    return Array.from(this.strategies.keys());
+  }
+  
+  /**
+   * Extracts references from text using specified strategies
+   * 
+   * @param {string} text - Text to extract references from
+   * @param {string[]} [strategyNames] - Strategies to use (defaults to all)
+   * @returns {string[]} - Array of extracted reference IRIs
+   */
+  extract(text, strategyNames) {
+    if (!text || typeof text !== 'string') {
+      return [];
+    }
+    
+    // If no specific strategies provided, use all registered strategies
+    const strategiesToUse = strategyNames || Array.from(this.strategies.keys());
+    
+    // Apply each requested strategy and collect results
+    const allReferences = [];
+    
+    for (const name of strategiesToUse) {
+      const strategy = this.strategies.get(name);
+      if (strategy) {
+        const references = strategy.extract(text);
+        allReferences.push(...references);
+      }
+    }
+    
+    // Return unique references
+    return [...new Set(allReferences)];
+  }
+}
+
+export { ReferenceExtractor };

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -101,7 +101,10 @@ function generateRawMetadata(context, metadata) {
     label: metadata.title,
     ...metadata,
     distributions: getRawDataDistributions(context, datatable),
-    references: getRawDataReferences(context, metadata.description),
+    references: removeDuplicateStrings([
+      ...(metadata.references || []), 
+      ...getRawDataReferences(context, metadata.description)
+    ]),
   }
 }
 
@@ -270,4 +273,8 @@ export function removeDuplicate(data, distinctProperties) {
   return data.filter((value, index, self) =>
     self.findIndex(v => distinctProperties.every(k => v[k] === value[k])) === index
   );
+}
+
+export function removeDuplicateStrings(strings) {
+  return [...new Set(strings)];
 }

--- a/src/normalization/utils.js
+++ b/src/normalization/utils.js
@@ -4,7 +4,11 @@ import { lookup } from 'mime-types';
 import { resolve } from 'path';
 import { info } from '../utils/logging.js';
 import { exec, throwOnError } from '../utils/sh-exec.js';
-import { getVersionTag, getCodeRepository, getCommitUrl } from '../utils/git.js';
+import { getCodeRepository, getCommitUrl } from '../utils/git.js';
+import { ReferenceExtractor } from './reference-extractor/reference-extractor.js';
+import { DOIExtractor } from './reference-extractor/doi-extractor.js';
+import { BioRxivExtractor } from './reference-extractor/biorxiv-extractor.js';
+import { get } from 'http';
 
 export function readMetadata(context) {
   const { path } = context.selectedDigitalObject;
@@ -96,7 +100,8 @@ function generateRawMetadata(context, metadata) {
     id: `${getMetadataUrl(context)}#raw-data`,
     label: metadata.title,
     ...metadata,
-    distributions: getRawDataDistributions(context, datatable)
+    distributions: getRawDataDistributions(context, datatable),
+    references: getRawDataReferences(context, metadata.description),
   }
 }
 
@@ -219,6 +224,14 @@ function getRawDataDistributions(context, datatable) {
       mediaType: lookup(downloadUrl),
     };
   }))
+}
+
+function getRawDataReferences(context, description) {
+  const extractor = new ReferenceExtractor();
+  extractor.registerStrategy('doi', new DOIExtractor());
+  extractor.registerStrategy('biorxiv', new BioRxivExtractor());
+
+  return extractor.extract(description);
 }
 
 function getDatasetIri(context) {


### PR DESCRIPTION
Highlights:
* Can extract references that use DOI and BioRxiv patterns.
* References explicitly mentioned in the metadata.yaml (instead of in description text) will be merged accordingly.