### PR TITLE
Implementing `reconstruct` sub-command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ digital-objects/*/*/*/normalized
 digital-objects/*/*/*/enriched
 scratch
 schemas/generated/*
+.store/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -299,3 +300,6 @@ dist
 
 # VSCode settings
 .vscode
+
+# MacOS specific ignores
+.DS_Store

--- a/schemas/src/digital-objects/2d-ftu.yaml
+++ b/schemas/src/digital-objects/2d-ftu.yaml
@@ -175,5 +175,6 @@ slots:
     description: >-
       Indicates the part of the illustration to which this node belongs to
       connect to the overall FTU structure.
+    range: EntityID
     annotations:
       owl: AnnotationProperty, AnnotationAssertion

--- a/schemas/src/digital-objects/asct-b.yaml
+++ b/schemas/src/digital-objects/asct-b.yaml
@@ -137,12 +137,7 @@ classes:
       - lipid_marker_list
       - metabolites_marker_list
       - proteoforms_marker_list
-      - references
-    slot_usage:
-      references:
-        range: string
-        annotations:
-          owl: AnnotationAssertion, AnnotationProperty
+      - reference_list
 
   AnatomicalStructureRecord:
     title: Anatomical Structure Record
@@ -187,6 +182,21 @@ classes:
       - ccf_pref_label
       - ccf_biomarker_type
       - source_concept
+      - record_number
+      - order_number
+
+  ReferenceRecord:
+    title: Reference Record
+    description: >-
+      A reference record represents a specific value in the ASCT+B table, 
+      located in the "REF" column, identified by its row (record number) and 
+      column (order number).
+    mixins:
+      - Named
+      - Instance
+    slots:
+      - doi
+      - external_id
       - record_number
       - order_number
 
@@ -471,6 +481,32 @@ slots:
     inlined_as_list: true
     range: BiomarkerRecord
     slot_uri: ccf:proteoform_marker
+    annotations:
+      owl: AnnotationAssertion, AnnotationProperty
+  reference_list:
+    title: reference list
+    description: List of references for the ASCT+B record.
+    required: false
+    multivalued: true
+    inlined_as_list: true
+    range: ReferenceRecord
+    slot_uri: ccf:reference
+    annotations:
+      owl: AnnotationAssertion, AnnotationProperty
+  doi:
+    title: doi
+    description: Digital Object Identifier for the reference record.
+    required: true
+    slot_uri: ccf:doi
+    range: uriorcurie
+    annotations:
+      owl: AnnotationAssertion, AnnotationProperty
+  external_id:
+    title: external id
+    description: External identifier for the reference record.
+    required: false
+    slot_uri: ccf:external_id
+    range: string
     annotations:
       owl: AnnotationAssertion, AnnotationProperty
   primary_cell_type:

--- a/schemas/src/digital-objects/omap.yaml
+++ b/schemas/src/digital-objects/omap.yaml
@@ -364,7 +364,6 @@ slots:
     title: author ORCID
     description: Reference to the author by the ORCID identifier.
     required: false
-    range: Named
     inlined: false
     multivalued: true
     annotations:

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,7 @@ import { newDraft } from './drafting/new-draft.js';
 import { enrich } from './enrichment/enrich.js';
 import { finalize } from './finalizing/finalize.js';
 import { validate } from './validation/validate.js';
+import { reconstruct } from './reconstruction/reconstruct.js';
 import { deployDoiXml } from './finalizing/misc-files.js';
 import { genAsctbCollectionJson } from './gen-asctb-collection-json.js';
 import { list } from './list.js';
@@ -116,6 +117,14 @@ program
   .argument('<digital-object-path>', 'Path to the digital object relative to DO_HOME')
   .action((str, _options, command) => {
     enrich(getContext(program, command, str));
+  });
+
+program
+  .command('reconstruct')
+  .description('Reconstructs a given digital object from the enriched graph data')
+  .argument('<digital-object-path>', 'Path to the digital object relative to DO_HOME')
+  .action((str, _options, command) => {
+    reconstruct(getContext(program, command, str));
   });
 
 program

--- a/src/normalization/asct-b-utils/api.model.js
+++ b/src/normalization/asct-b-utils/api.model.js
@@ -146,11 +146,15 @@ export function createObject(name, structureType) {
 }
 
 export class Reference {
-  constructor(id) {
-    this.id = id;
+  constructor(name) {
+    this.name = !this.checkIsDoi(name) ? name : '';
   }
   isValid() {
-    return !!this.id || !!this.doi || !!this.notes;
+    return !!this.id;
+  }
+  checkIsDoi(str) {
+    const doiRegex = /(10\.\d{4,9}\/[\w\-._;()/:]+)/i;
+    return doiRegex.test(str);
   }
 }
 
@@ -219,6 +223,15 @@ export class Row {
     this.cell_types = this.cell_types.filter((s) => s.isValid());
     this.ftu_types = this.ftu_types.filter((s) => s.isValid());
     this.references = this.references.filter((s) => s.isValid());
+    
+    // Remove duplicates based on 'id' property
+    const seenIds = new Set();
+    this.references = this.references.filter((s) => {
+      if (s.id && seenIds.has(s.id)) return false;
+      if (s.id) seenIds.add(s.id);
+      return true;
+    });
+    
     this.biomarkers_gene = this.biomarkers_gene.filter((s) => s.isValid());
     this.biomarkers_protein = this.biomarkers_protein.filter((s) => s.isValid());
     this.biomarkers_lipids = this.biomarkers_lipids.filter((s) => s.isValid());

--- a/src/normalization/normalize-asct-b.js
+++ b/src/normalization/normalize-asct-b.js
@@ -424,7 +424,7 @@ function generateReferenceInstance(context, recordNumber, data, index) {
     order_number: orderNumber,
   };
   if (name) {
-    obj.external_id = name;
+    obj.external_id = normalizePubMedUrl(name);
   }
   return obj;
 }
@@ -482,6 +482,17 @@ function checkNotEmpty(str) {
 function checkIsDoi(str) {
   const doiRegex = /(10\.\d{4,9}\/[\w\-._;()/:]+)/i;
   return doiRegex.test(str);
+}
+
+function normalizePubMedUrl(str) {
+  // Check if the string contains a PubMed URL
+  const pubmedRegex = /(?:https?:\/\/(?:www\.)?(?:pubmed\.ncbi\.nlm\.nih\.gov|ncbi\.nlm\.nih\.gov\/pubmed)\/(\d+)(?:\/?$|\/.*))/i;
+  const match = str.match(pubmedRegex);
+  if (match) {
+    const pmid = match[1];
+    return `PMID:${pmid}`;
+  }
+  return str;
 }
 
 function removeDuplicates(array) {

--- a/src/normalization/normalize-omap.js
+++ b/src/normalization/normalize-omap.js
@@ -66,19 +66,24 @@ function normalizeData(context, data) {
 function normalizeAntibodyData(context, data) {
   return data
     .map((row) => {
-      return new ObjectBuilder()
+      const antibody = new ObjectBuilder()
         .append('id', getAntibodyIri(row.rrid))
         .append('parent_class', 'ccf:Antibody')
         .append('antibody_type', row.HGNC_ID ? 'Primary' : 'Secondary')
         .append('host', row.host)
-        .append('clonality', row.clonality)
-        .append('clone_id', `${row.clone_id}`)
         .append('conjugate', row.conjugate)
         .append('fluorescent', row.fluorescent_reporter)
         .append('recombinant', row.recombinant)
         .append('producer', row.vendor)
         .append('catalog_number', `${row.catalog_number}`)
         .build();
+      if (row.clonality) {
+        antibody.clonality = row.clonality;
+      }
+      if (row.clone_id) {
+        antibody.clone_id = row.clone_id + "";
+      }
+      return antibody;
     })
     .reduce(mergeDuplicateAntibodyData, []);
 }

--- a/src/reconstruction/queries/get-2d-ftu-records.rq
+++ b/src/reconstruction/queries/get-2d-ftu-records.rq
@@ -1,0 +1,42 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT
+  ?node_id_str
+  ?node_group_str
+  ?node_label_str
+  ?node_mapped_to_str
+  ?ftu_illustration
+  ?tissue_label_str
+  ?tissue_mapped_to_str
+  ?organ_label_str
+  ?organ_mapped_to_str
+WHERE {
+  ?ftu_illustration_node a ccf:FtuIllustrationNode ;
+      ccf:node_name ?node_id ;
+      ccf:node_group ?node_group ;
+      ccf:representation_of ?biological_concept ;
+      ccf:part_of_illustration ?ftu_illustration .
+
+  ?biological_concept rdfs:label ?node_label .
+
+  ?ftu_illustration ccf:representation_of ?organ_concept .
+  ?ftu_illustration ccf:ccf_located_in ?parent_organ_concept .
+
+  ?organ_concept rdfs:label ?tissue_label .
+  ?organ_concept oboInOwl:id ?tissue_mapped_to .
+
+  ?parent_organ_concept rdfs:label ?organ_label .
+  ?parent_organ_concept oboInOwl:id ?organ_mapped_to .
+
+  # Implement BIND(STR()) to convert results to strings
+  BIND(STR(?node_id) AS ?node_id_str)
+  BIND(STR(?node_group) AS ?node_group_str)
+  BIND(STR(?node_label) AS ?node_label_str)
+  BIND(STR(?biological_concept) AS ?node_mapped_to_str)
+  BIND(STR(?tissue_label) AS ?tissue_label_str)
+  BIND(STR(?tissue_mapped_to) AS ?tissue_mapped_to_str)
+  BIND(STR(?organ_label) AS ?organ_label_str)
+  BIND(STR(?organ_mapped_to) AS ?organ_mapped_to_str)
+}

--- a/src/reconstruction/queries/get-asct-b-metadata.rq
+++ b/src/reconstruction/queries/get-asct-b-metadata.rq
@@ -1,0 +1,67 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema1: <http://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT 
+    ?tableTitle
+    ?authorNames
+    ?authorOrcids
+    ?reviewerNames
+    ?reviewerOrcids
+    ?generalPublications
+    ?dataDoi
+    ?date
+    ?versionNumber
+WHERE {
+    # Find concepts with raw-data suffix
+    ?rawDataConcept a dcat:Dataset .
+    FILTER(STRENDS(STR(?rawDataConcept), "#raw-data"))
+    
+    # Get table title and bind to string
+    ?rawDataConcept dct:title ?tableTitleRaw .
+    BIND(STR(?tableTitleRaw) AS ?tableTitle)
+    
+    # Get data DOI and bind to string
+    ?rawDataConcept ccf:doi ?dataDoiRaw .
+    BIND(STR(?dataDoiRaw) AS ?dataDoi)
+    
+    # Get date created and bind to string
+    ?rawDataConcept schema1:dateCreated ?dateRaw .
+    BIND(STR(?dateRaw) AS ?date)
+    
+    # Extract version number from IRI
+    BIND(REPLACE(STR(?rawDataConcept), ".*/([^/]+)#raw-data$", "$1") AS ?versionNumber)
+    
+    # Get author names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?authorName; separator="; ") AS ?authorNames)
+               (GROUP_CONCAT(DISTINCT ?authorOrcid; separator="; ") AS ?authorOrcids)
+        WHERE {
+            ?rawDataConcept dct:creator ?author .
+            ?author rdfs:label ?authorName .
+            ?author schema1:identifier ?authorOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # Get reviewer names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?reviewerName; separator="; ") AS ?reviewerNames)
+               (GROUP_CONCAT(DISTINCT ?reviewerOrcid; separator="; ") AS ?reviewerOrcids)
+        WHERE {
+            ?rawDataConcept schema1:reviewedBy ?reviewer .
+            ?reviewer rdfs:label ?reviewerName .
+            ?reviewer schema1:identifier ?reviewerOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # General publications is blank
+    BIND("" AS ?generalPublications)
+}

--- a/src/reconstruction/queries/get-asct-b-records.rq
+++ b/src/reconstruction/queries/get-asct-b-records.rq
@@ -3,7 +3,8 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dct: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT ?record_number_str ?record_references_str
+SELECT DISTINCT ?record_number_str 
+       (GROUP_CONCAT(DISTINCT ?record_references_str; SEPARATOR=", ") AS ?record_references_str)
        ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
        ?ct_pref_label_str ?ct_source_concept_str ?ct_concept_label_str ?ct_record_number_str ?ct_order_number_str
        ?bm_pref_label_str ?bm_biomarker_type_str ?bm_source_concept_str ?bm_concept_label_str ?bm_record_number_str ?bm_order_number_str
@@ -122,4 +123,7 @@ WHERE {
     BIND(STR(?bm_record_number) AS ?bm_record_number_str)
     BIND(STR(?bm_order_number) AS ?bm_order_number_str)
 }
+GROUP BY ?record_number_str ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
+         ?ct_pref_label_str ?ct_source_concept_str ?ct_concept_label_str ?ct_record_number_str ?ct_order_number_str
+         ?bm_pref_label_str ?bm_biomarker_type_str ?bm_source_concept_str ?bm_concept_label_str ?bm_record_number_str ?bm_order_number_str
 ORDER BY ?record_number_str ?as_order_number_str ?ct_order_number_str ?bm_order_number_str

--- a/src/reconstruction/queries/get-asct-b-records.rq
+++ b/src/reconstruction/queries/get-asct-b-records.rq
@@ -1,0 +1,125 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?record_number_str ?record_references_str
+       ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
+       ?ct_pref_label_str ?ct_source_concept_str ?ct_concept_label_str ?ct_record_number_str ?ct_order_number_str
+       ?bm_pref_label_str ?bm_biomarker_type_str ?bm_source_concept_str ?bm_concept_label_str ?bm_record_number_str ?bm_order_number_str
+WHERE {
+    # Get ASCT+B Records
+    ?record rdf:type ccf:AsctbRecord .
+    OPTIONAL { ?record ccf:record_number ?record_number }
+    OPTIONAL { ?record dct:references ?record_references }
+    
+    # Get Anatomical Structure Records
+    OPTIONAL {
+        ?record ccf:anatomical_structure ?anatomical_structure .
+        ?anatomical_structure rdf:type ccf:AnatomicalStructureRecord .
+        OPTIONAL { ?anatomical_structure ccf:ccf_pref_label ?as_pref_label }
+        OPTIONAL { ?anatomical_structure ccf:source_concept ?as_source_concept .
+            ?as_source_concept rdfs:label ?as_concept_label
+        }
+        OPTIONAL { ?anatomical_structure ccf:record_number ?as_record_number }
+        OPTIONAL { ?anatomical_structure ccf:order_number ?as_order_number }
+    }
+    
+    # Get Cell Type Records
+    OPTIONAL {
+        ?record ccf:cell_type ?cell_type .
+        ?cell_type rdf:type ccf:CellTypeRecord .
+        OPTIONAL { ?cell_type ccf:ccf_pref_label ?ct_pref_label }
+        OPTIONAL { ?cell_type ccf:source_concept ?ct_source_concept .
+            ?ct_source_concept rdfs:label ?ct_concept_label
+        }
+        OPTIONAL { ?cell_type ccf:record_number ?ct_record_number }
+        OPTIONAL { ?cell_type ccf:order_number ?ct_order_number }
+    }
+    
+    # Get Biomarker Records (Gene Markers)
+    OPTIONAL {
+        ?record ccf:gene_marker ?biomarker .
+        ?biomarker rdf:type ccf:BiomarkerRecord .
+        OPTIONAL { ?biomarker ccf:ccf_pref_label ?bm_pref_label }
+        OPTIONAL { ?biomarker ccf:ccf_biomarker_type ?bm_biomarker_type }
+        OPTIONAL { ?biomarker ccf:source_concept ?bm_source_concept .
+            ?bm_source_concept rdfs:label ?bm_concept_label
+        }
+        OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
+        OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
+    }
+    
+    # Get Biomarker Records (Protein Markers)
+    OPTIONAL {
+        ?record ccf:protein_marker ?biomarker .
+        ?biomarker rdf:type ccf:BiomarkerRecord .
+        OPTIONAL { ?biomarker ccf:ccf_pref_label ?bm_pref_label }
+        OPTIONAL { ?biomarker ccf:ccf_biomarker_type ?bm_biomarker_type }
+        OPTIONAL { ?biomarker ccf:source_concept ?bm_source_concept .
+            ?bm_source_concept rdfs:label ?bm_concept_label
+        }
+        OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
+        OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
+    }
+    
+    # Get Biomarker Records (Lipid Markers)
+    OPTIONAL {
+        ?record ccf:lipid_marker ?biomarker .
+        ?biomarker rdf:type ccf:BiomarkerRecord .
+        OPTIONAL { ?biomarker ccf:ccf_pref_label ?bm_pref_label }
+        OPTIONAL { ?biomarker ccf:ccf_biomarker_type ?bm_biomarker_type }
+        OPTIONAL { ?biomarker ccf:source_concept ?bm_source_concept .
+            ?bm_source_concept rdfs:label ?bm_concept_label
+        }
+        OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
+        OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
+    }
+    
+    # Get Biomarker Records (Metabolite Markers)
+    OPTIONAL {
+        ?record ccf:metabolite_marker ?biomarker .
+        ?biomarker rdf:type ccf:BiomarkerRecord .
+        OPTIONAL { ?biomarker ccf:ccf_pref_label ?bm_pref_label }
+        OPTIONAL { ?biomarker ccf:ccf_biomarker_type ?bm_biomarker_type }
+        OPTIONAL { ?biomarker ccf:source_concept ?bm_source_concept .
+            ?bm_source_concept rdfs:label ?bm_concept_label
+        }
+        OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
+        OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
+    }
+    
+    # Get Biomarker Records (Proteoform Markers)
+    OPTIONAL {
+        ?record ccf:proteoform_marker ?biomarker .
+        ?biomarker rdf:type ccf:BiomarkerRecord .
+        OPTIONAL { ?biomarker ccf:ccf_pref_label ?bm_pref_label }
+        OPTIONAL { ?biomarker ccf:ccf_biomarker_type ?bm_biomarker_type }
+        OPTIONAL { ?biomarker ccf:source_concept ?bm_source_concept .
+            ?bm_source_concept rdfs:label ?bm_concept_label
+        }
+        OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
+        OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
+    }
+    
+    # Bind all values to STR
+    BIND(STR(?record_number) AS ?record_number_str)
+    BIND(STR(?record_references) AS ?record_references_str)
+    BIND(STR(?as_pref_label) AS ?as_pref_label_str)
+    BIND(STR(?as_source_concept) AS ?as_source_concept_str)
+    BIND(STR(?as_concept_label) AS ?as_concept_label_str)
+    BIND(STR(?as_record_number) AS ?as_record_number_str)
+    BIND(STR(?as_order_number) AS ?as_order_number_str)
+    BIND(STR(?ct_pref_label) AS ?ct_pref_label_str)
+    BIND(STR(?ct_source_concept) AS ?ct_source_concept_str)
+    BIND(STR(?ct_concept_label) AS ?ct_concept_label_str)
+    BIND(STR(?ct_record_number) AS ?ct_record_number_str)
+    BIND(STR(?ct_order_number) AS ?ct_order_number_str)
+    BIND(STR(?bm_pref_label) AS ?bm_pref_label_str)
+    BIND(STR(?bm_biomarker_type) AS ?bm_biomarker_type_str)
+    BIND(STR(?bm_source_concept) AS ?bm_source_concept_str)
+    BIND(STR(?bm_concept_label) AS ?bm_concept_label_str)
+    BIND(STR(?bm_record_number) AS ?bm_record_number_str)
+    BIND(STR(?bm_order_number) AS ?bm_order_number_str)
+}
+ORDER BY ?record_number_str ?as_order_number_str ?ct_order_number_str ?bm_order_number_str

--- a/src/reconstruction/queries/get-asct-b-records.rq
+++ b/src/reconstruction/queries/get-asct-b-records.rq
@@ -4,15 +4,14 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dct: <http://purl.org/dc/terms/>
 
 SELECT DISTINCT ?record_number_str 
-       (GROUP_CONCAT(DISTINCT ?record_references_str; SEPARATOR=", ") AS ?record_references_str)
        ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
        ?ct_pref_label_str ?ct_source_concept_str ?ct_concept_label_str ?ct_record_number_str ?ct_order_number_str
        ?bm_pref_label_str ?bm_biomarker_type_str ?bm_source_concept_str ?bm_concept_label_str ?bm_record_number_str ?bm_order_number_str
+       ?ref_doi_str ?ref_external_id_str ?ref_record_number_str ?ref_order_number_str
 WHERE {
     # Get ASCT+B Records
     ?record rdf:type ccf:AsctbRecord .
     OPTIONAL { ?record ccf:record_number ?record_number }
-    OPTIONAL { ?record dct:references ?record_references }
     
     # Get Anatomical Structure Records
     OPTIONAL {
@@ -102,10 +101,23 @@ WHERE {
         OPTIONAL { ?biomarker ccf:record_number ?bm_record_number }
         OPTIONAL { ?biomarker ccf:order_number ?bm_order_number }
     }
+
+    # Get Reference Records
+    OPTIONAL {
+        ?record ccf:reference ?reference .
+        ?reference rdf:type ccf:ReferenceRecord .
+        OPTIONAL { ?reference ccf:doi ?ref_doi }
+        OPTIONAL { ?reference ccf:external_id ?ref_external_id }
+        OPTIONAL { ?reference ccf:record_number ?ref_record_number }
+        OPTIONAL { ?reference ccf:order_number ?ref_order_number }
+    }
     
     # Bind all values to STR
     BIND(STR(?record_number) AS ?record_number_str)
-    BIND(STR(?record_references) AS ?record_references_str)
+    BIND(STR(?ref_doi) AS ?ref_doi_str)
+    BIND(STR(?ref_external_id) AS ?ref_external_id_str)
+    BIND(STR(?ref_record_number) AS ?ref_record_number_str)
+    BIND(STR(?ref_order_number) AS ?ref_order_number_str)
     BIND(STR(?as_pref_label) AS ?as_pref_label_str)
     BIND(STR(?as_source_concept) AS ?as_source_concept_str)
     BIND(STR(?as_concept_label) AS ?as_concept_label_str)
@@ -123,7 +135,9 @@ WHERE {
     BIND(STR(?bm_record_number) AS ?bm_record_number_str)
     BIND(STR(?bm_order_number) AS ?bm_order_number_str)
 }
-GROUP BY ?record_number_str ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
+GROUP BY ?record_number_str 
+         ?as_pref_label_str ?as_source_concept_str ?as_concept_label_str ?as_record_number_str ?as_order_number_str
          ?ct_pref_label_str ?ct_source_concept_str ?ct_concept_label_str ?ct_record_number_str ?ct_order_number_str
          ?bm_pref_label_str ?bm_biomarker_type_str ?bm_source_concept_str ?bm_concept_label_str ?bm_record_number_str ?bm_order_number_str
-ORDER BY ?record_number_str ?as_order_number_str ?ct_order_number_str ?bm_order_number_str
+         ?ref_doi_str ?ref_external_id_str ?ref_record_number_str ?ref_order_number_str
+ORDER BY ?record_number_str

--- a/src/reconstruction/queries/get-collection-records.rq
+++ b/src/reconstruction/queries/get-collection-records.rq
@@ -1,0 +1,10 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#> 
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+SELECT DISTINCT ?sub_graph_str
+WHERE {
+  ?ontology_id a owl:Ontology ;
+      prov:hadMember ?sub_graph
+
+  BIND(STR(?sub_graph) AS ?sub_graph_str)
+}

--- a/src/reconstruction/queries/get-ctann-metadata.rq
+++ b/src/reconstruction/queries/get-ctann-metadata.rq
@@ -1,0 +1,74 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema: <http://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT 
+    ?tableTitle
+    ?authorNames
+    ?authorOrcids
+    ?reviewerNames
+    ?reviewerOrcids
+    ?generalPublications
+    ?dataDoi
+    ?date
+    ?versionNumber
+WHERE {
+    # Find concepts with raw-data suffix
+    ?rawDataConcept a dcat:Dataset .
+    FILTER(STRENDS(STR(?rawDataConcept), "#raw-data"))
+    
+    # Get table title and bind to string
+    ?rawDataConcept dct:title ?tableTitleRaw .
+    BIND(STR(?tableTitleRaw) AS ?tableTitle)
+    
+    # Get data DOI and bind to string
+    ?rawDataConcept ccf:doi ?dataDoiRaw .
+    BIND(STR(?dataDoiRaw) AS ?dataDoi)
+    
+    # Get date created and bind to string
+    ?rawDataConcept schema:dateCreated ?dateRaw .
+    BIND(STR(?dateRaw) AS ?date)
+    
+    # Extract version number from IRI
+    BIND(REPLACE(STR(?rawDataConcept), ".*/([^/]+)#raw-data$", "$1") AS ?versionNumber)
+    
+    # Get author names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?authorName; separator="; ") AS ?authorNames)
+               (GROUP_CONCAT(DISTINCT ?authorOrcid; separator="; ") AS ?authorOrcids)
+        WHERE {
+            ?rawDataConcept dct:creator ?author .
+            ?author rdfs:label ?authorName .
+            ?author schema:identifier ?authorOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # Get reviewer names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?reviewerName; separator="; ") AS ?reviewerNames)
+               (GROUP_CONCAT(DISTINCT ?reviewerOrcid; separator="; ") AS ?reviewerOrcids)
+        WHERE {
+            ?rawDataConcept schema:reviewedBy ?reviewer .
+            ?reviewer rdfs:label ?reviewerName .
+            ?reviewer schema:identifier ?reviewerOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # General publications is blank
+        {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?generalPublication; separator="; ") AS ?generalPublications)
+        WHERE {
+            ?rawDataConcept dct:references ?generalPublication .
+        }
+        GROUP BY ?rawDataConcept
+    }
+}

--- a/src/reconstruction/queries/get-ctann-records.rq
+++ b/src/reconstruction/queries/get-ctann-records.rq
@@ -1,0 +1,53 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX sssom: <https://w3id.org/sssom/>
+PREFIX CL: <http://purl.obolibrary.org/obo/CL_>
+PREFIX UBERON: <http://purl.obolibrary.org/obo/UBERON_>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT 
+  ?Organ_Level_str
+  ?Organ_ID_str
+  ?Annotation_Label_str
+  ?Annotation_Label_ID_str
+  ?CL_Label_str
+  ?CL_ID_str
+  ?CL_Match_str
+  ?record_label_str
+  ?record_number
+WHERE {
+  ?ctAnnMapping a ccf:CtAnnMapping .
+  
+  # Get organ level and organ ID from extension properties
+  ?ctAnnMapping ccf:ext_organ_level ?Organ_Level .
+  ?ctAnnMapping ccf:ext_organ_id ?Organ_ID .
+  
+  # Get annotation label and ID from subject properties
+  ?ctAnnMapping sssom:subject_label ?Annotation_Label .
+  ?ctAnnMapping owl:annotatedSource ?Annotation_Label_ID .
+  
+  # Get CL (Cell Line) label and ID from object properties
+  ?ctAnnMapping sssom:object_label ?CL_Label .
+  ?ctAnnMapping owl:annotatedTarget ?CL_ID .
+  
+  # Get mapping justification as CL_Match
+  ?ctAnnMapping owl:annotatedProperty ?CL_Match .
+  
+  # Get record label to extract record number for ordering
+  ?ctAnnMapping rdfs:label ?record_label .
+  
+  # Extract record number from label like "Record 133"
+  BIND(xsd:integer(REPLACE(STR(?record_label), "^Record\\s+(\\d+)$", "$1")) AS ?record_number)
+  
+  # Bind all values to STR
+  BIND(STR(?Organ_Level) AS ?Organ_Level_str)
+  BIND(STR(?Organ_ID) AS ?Organ_ID_str)
+  BIND(STR(?Annotation_Label) AS ?Annotation_Label_str)
+  BIND(STR(?Annotation_Label_ID) AS ?Annotation_Label_ID_str)
+  BIND(STR(?CL_Label) AS ?CL_Label_str)
+  BIND(STR(?CL_ID) AS ?CL_ID_str)
+  BIND(STR(?CL_Match) AS ?CL_Match_str)
+  BIND(STR(?record_label) AS ?record_label_str)
+}
+ORDER BY ?record_number 

--- a/src/reconstruction/queries/get-omap-metadata.rq
+++ b/src/reconstruction/queries/get-omap-metadata.rq
@@ -1,0 +1,74 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX schema1: <http://schema.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT 
+    ?tableTitle
+    ?authorNames
+    ?authorOrcids
+    ?reviewerNames
+    ?reviewerOrcids
+    ?generalPublications
+    ?dataDoi
+    ?date
+    ?versionNumber
+WHERE {
+    # Find concepts with raw-data suffix
+    ?rawDataConcept a dcat:Dataset .
+    FILTER(STRENDS(STR(?rawDataConcept), "#raw-data"))
+    
+    # Get table title and bind to string
+    ?rawDataConcept dct:title ?tableTitleRaw .
+    BIND(STR(?tableTitleRaw) AS ?tableTitle)
+    
+    # Get data DOI and bind to string
+    ?rawDataConcept ccf:doi ?dataDoiRaw .
+    BIND(STR(?dataDoiRaw) AS ?dataDoi)
+    
+    # Get date created and bind to string
+    ?rawDataConcept schema1:dateCreated ?dateRaw .
+    BIND(STR(?dateRaw) AS ?date)
+    
+    # Extract version number from IRI
+    BIND(REPLACE(STR(?rawDataConcept), ".*/([^/]+)#raw-data$", "$1") AS ?versionNumber)
+    
+    # Get author names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?authorName; separator="; ") AS ?authorNames)
+               (GROUP_CONCAT(DISTINCT ?authorOrcid; separator="; ") AS ?authorOrcids)
+        WHERE {
+            ?rawDataConcept dct:creator ?author .
+            ?author rdfs:label ?authorName .
+            ?author schema1:identifier ?authorOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # Get reviewer names and ORCIDs
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?reviewerName; separator="; ") AS ?reviewerNames)
+               (GROUP_CONCAT(DISTINCT ?reviewerOrcid; separator="; ") AS ?reviewerOrcids)
+        WHERE {
+            ?rawDataConcept schema1:reviewedBy ?reviewer .
+            ?reviewer rdfs:label ?reviewerName .
+            ?reviewer schema1:identifier ?reviewerOrcid .
+        }
+        GROUP BY ?rawDataConcept
+    }
+    
+    # General publications is blank
+    {
+        SELECT ?rawDataConcept 
+               (GROUP_CONCAT(DISTINCT ?generalPublication; separator="; ") AS ?generalPublications)
+        WHERE {
+            ?rawDataConcept dct:references ?generalPublication .
+        }
+        GROUP BY ?rawDataConcept
+    }
+}

--- a/src/reconstruction/queries/get-omap-records.rq
+++ b/src/reconstruction/queries/get-omap-records.rq
@@ -1,0 +1,122 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT 
+    ?experiment_str
+    ?study_method_str ?tissue_preservation_str
+    (GROUP_CONCAT(DISTINCT ?protocol_doi; separator=", ") AS ?protocol_doi_str)
+    (GROUP_CONCAT(DISTINCT ?author_orcid; separator=", ") AS ?author_orcid_str)
+    ?sample_organ_str ?sample_organ_label_str
+    ?cycle_str ?cycle_number_str ?used_antibody_str
+    ?antibody_manufacturer_str ?antibody_type_str
+    ?concentration_str ?dilution_str ?is_core_panel_str
+    ?registered_antibody_str ?clone_id_str ?lot_number_str 
+    ?catalog_number_str ?host_str ?isotype_str 
+    ?clonality_str ?conjugate_str ?recombinant_str 
+    ?record_number_str ?antibody_str 
+    (GROUP_CONCAT(DISTINCT ?detected_protein_id; separator=", ") AS ?detected_protein_id_str) 
+    (GROUP_CONCAT(DISTINCT ?detected_protein_label; separator=", ") AS ?detected_protein_label_str)
+    (GROUP_CONCAT(DISTINCT ?uniprot_id; separator=", ") AS ?uniprot_id_str)
+    ?rationale_str
+WHERE {
+    # Get MultiplexedAntibodyBasedImagingExperiment instances
+    ?experiment rdf:type ccf:MultiplexedAntibodyBasedImagingExperiment .
+    
+    # Experiment properties
+    ?experiment ccf:study_method ?study_method .
+    ?experiment ccf:tissue_preservation ?tissue_preservation .
+    OPTIONAL { ?experiment ccf:protocol_doi ?protocol_doi . }
+    OPTIONAL { ?experiment ccf:author_orcid ?author_orcid . }
+    
+    # Sample organ information
+    ?experiment ccf:sample_organ ?sample_organ .
+    OPTIONAL { ?sample_organ rdfs:label ?sample_organ_label . }
+    
+    # Experiment cycles
+    ?experiment ccf:has_cycle ?cycle .
+    ?cycle rdf:type ccf:ExperimentCycle .
+    OPTIONAL { ?cycle ccf:cycle_number ?cycle_number . }
+    
+    # Antibodies used in cycles
+    OPTIONAL {
+      ?cycle ccf:uses_antibody ?used_antibody .
+      ?used_antibody rdf:type ccf:ExperimentUsedAntibody .
+      OPTIONAL { ?used_antibody ccf:concentration ?concentration . }
+      OPTIONAL { ?used_antibody ccf:dilution ?dilution . }
+      OPTIONAL { ?used_antibody ccf:is_core_panel ?is_core_panel . }
+      OPTIONAL { ?used_antibody ccf:record_number ?record_number . }
+
+      OPTIONAL {
+        ?used_antibody ccf:detects ?detected_protein_id .
+
+        # Protein detection information
+        OPTIONAL {
+          ?detects_statement rdf:type owl:Axiom .
+          ?detects_statement owl:annotatedSource ?used_antibody .
+          ?detects_statement owl:annotatedTarget ?detected_protein_id .
+          ?detects_statement owl:annotatedProperty ccf:detects .
+          ?detects_statement ccf:rationale ?rationale .
+        }
+
+        ?detected_protein_id rdfs:label ?detected_protein_label .
+        ?detected_protein_id oboInOwl:hasDbXref ?uniprot_id .
+
+        # UniProt information - mandatory filtering for UniProt IDs only
+        ?hasDbXref_statement rdf:type owl:Axiom .
+        ?hasDbXref_statement owl:annotatedSource ?detected_protein_id .
+        ?hasDbXref_statement owl:annotatedTarget ?uniprot_id .
+        ?hasDbXref_statement owl:annotatedProperty oboInOwl:hasDbXref .
+        ?hasDbXref_statement rdfs:comment "UniProt ID"^^xsd:string.
+      }
+
+      # Registered antibody details
+      OPTIONAL {
+        ?used_antibody ccf:based_on ?registered_antibody .
+        ?registered_antibody rdf:type ?antibody .
+        FILTER(?antibody != owl:NamedIndividual)
+        OPTIONAL { ?registered_antibody ccf:lot_number ?lot_number . }
+        OPTIONAL { ?registered_antibody ccf:isotype ?isotype . }
+        OPTIONAL { ?antibody ccf:antibody_manufacturer ?antibody_manufacturer . }
+        OPTIONAL { ?antibody ccf:antibody_type ?antibody_type . }
+        OPTIONAL { ?antibody ccf:catalog_number ?catalog_number . }
+        OPTIONAL { ?antibody ccf:host ?host . }
+        OPTIONAL { ?antibody ccf:recombinant ?recombinant . }
+        OPTIONAL { ?antibody ccf:clone_id ?clone_id . }
+        OPTIONAL { ?antibody ccf:clonality ?clonality . }
+        OPTIONAL { ?antibody ccf:conjugate ?conjugate . }
+      }
+    }
+    
+    # Bind all values to STR
+    BIND(STR(?experiment) AS ?experiment_str)
+    BIND(STR(?study_method) AS ?study_method_str)
+    BIND(STR(?tissue_preservation) AS ?tissue_preservation_str)
+    BIND(STR(?sample_organ) AS ?sample_organ_str)
+    BIND(STR(?sample_organ_label) AS ?sample_organ_label_str)
+    BIND(STR(?cycle) AS ?cycle_str)
+    BIND(STR(?cycle_number) AS ?cycle_number_str)
+    BIND(STR(?used_antibody) AS ?used_antibody_str)
+    BIND(STR(?antibody_manufacturer) AS ?antibody_manufacturer_str)
+    BIND(STR(?antibody_type) AS ?antibody_type_str)
+    BIND(STR(?concentration) AS ?concentration_str)
+    BIND(STR(?dilution) AS ?dilution_str)
+    BIND(STR(?is_core_panel) AS ?is_core_panel_str)
+    BIND(STR(?record_number) AS ?record_number_str)
+    BIND(STR(?registered_antibody) AS ?registered_antibody_str)
+    BIND(STR(?clone_id) AS ?clone_id_str)
+    BIND(STR(?lot_number) AS ?lot_number_str)
+    BIND(STR(?catalog_number) AS ?catalog_number_str)
+    BIND(STR(?host) AS ?host_str)
+    BIND(STR(?isotype) AS ?isotype_str)
+    BIND(STR(?clonality) AS ?clonality_str)
+    BIND(STR(?conjugate) AS ?conjugate_str)
+    BIND(STR(?recombinant) AS ?recombinant_str)
+    BIND(STR(?antibody) AS ?antibody_str)
+    BIND(STR(?rationale) AS ?rationale_str)
+}
+GROUP BY ?experiment_str ?study_method_str ?tissue_preservation_str ?sample_organ_str ?sample_organ_label_str ?cycle_str ?cycle_number_str ?used_antibody_str ?antibody_manufacturer_str ?antibody_type_str ?concentration_str ?dilution_str ?is_core_panel_str ?record_number_str ?registered_antibody_str ?clone_id_str ?lot_number_str ?catalog_number_str ?host_str ?isotype_str ?clonality_str ?conjugate_str ?recombinant_str ?antibody_str ?detected_protein_id_str ?detected_protein_label_str ?uniprot_id_str ?rationale_str
+ORDER BY ?record_number_str ?cycle_number_str

--- a/src/reconstruction/queries/get-ref-organ-records.rq
+++ b/src/reconstruction/queries/get-ref-organ-records.rq
@@ -1,0 +1,26 @@
+PREFIX ccf: <http://purl.org/ccf/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT
+  ?record_order_str
+  ?node_name_str
+  ?ontology_id_str
+  ?label_str
+WHERE {
+  ?spatialEntity a ccf:SpatialEntity ;
+      skos:prefLabel ?label ;
+      ccf:rui_rank ?record_order ;
+      ccf:representation_of ?organ_concept ;
+      ccf:has_object_reference ?objectReference .
+
+  ?objectReference ccf:file_subpath ?node_name .
+  ?organ_concept oboInOwl:id ?ontology_id .
+
+  # Use BIND(STR()) to convert the results into string
+  BIND(STR(?record_order) AS ?record_order_str)
+  BIND(STR(?node_name) AS ?node_name_str) 
+  BIND(STR(?ontology_id) AS ?ontology_id_str)
+  BIND(STR(?label) AS ?label_str)
+}
+ORDER BY ?record_order

--- a/src/reconstruction/queries/get-ref-organ-records.rq
+++ b/src/reconstruction/queries/get-ref-organ-records.rq
@@ -9,13 +9,14 @@ SELECT DISTINCT
   ?label_str
 WHERE {
   ?spatialEntity a ccf:SpatialEntity ;
-      skos:prefLabel ?label ;
       ccf:rui_rank ?record_order ;
       ccf:representation_of ?organ_concept ;
       ccf:has_object_reference ?objectReference .
 
   ?objectReference ccf:file_subpath ?node_name .
-  ?organ_concept oboInOwl:id ?ontology_id .
+
+  ?organ_concept rdfs:label ?label ;
+      oboInOwl:id ?ontology_id .
 
   # Use BIND(STR()) to convert the results into string
   BIND(STR(?record_order) AS ?record_order_str)

--- a/src/reconstruction/reconstruct-2d-ftu.js
+++ b/src/reconstruction/reconstruct-2d-ftu.js
@@ -1,0 +1,84 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { info, error } from '../utils/logging.js';
+import { writeReconstructedData, executeBlazegraphQuery, loadGraph, shortenId, quoteIfNeeded } from './utils.js';
+
+export function reconstruct2dFtu(context) {
+  try {   
+    loadGraph(context);
+    queryGraph(context);
+    transformRecords(context);
+
+    info('2D FTU reconstruction completed successfully');
+  } catch (err) {
+    error('Error during 2D FTU reconstruction:', err);
+    throw err;
+  }
+}
+
+function queryGraph(context) {
+  try {
+    const processorHome = resolve(context.processorHome);
+    const reconstructPath = resolve(context.reconstructionHome);
+    const journalPath = resolve(reconstructPath, 'blazegraph.jnl');
+
+    // Query records only (no metadata)
+    const recordsQueryPath = resolve(processorHome, 'src/reconstruction/queries/get-2d-ftu-records.rq');
+    const recordsOutputPath = resolve(reconstructPath, 'records.tsv');
+    executeBlazegraphQuery(journalPath, recordsQueryPath, recordsOutputPath);
+
+    info('Graph query completed successfully');
+  } catch (err) {
+    error('Error during graph query:', err);
+    throw err;
+  }
+}
+
+function transformRecords(context) {
+  const reconstructPath = resolve(context.reconstructionHome);
+  const inputFilePath = resolve(reconstructPath, 'records.tsv');
+
+  info('Reading TSV file...');
+  const fileContent = readFileSync(inputFilePath, 'utf8');
+
+  // Parse TSV content
+  const lines = fileContent.trim().split(/\r?\n/); // Handle both \r\n and \n line endings
+  const headers = lines[0].split('\t');
+  const dataRows = lines.slice(1).map(line => {
+    const values = line.split('\t');
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || '';
+    });
+    return row;
+  });
+
+  // Transform rows to CSV format
+  const transformedRows = dataRows.map(row => {
+    return {
+      'node_id': row['?node_id_str'] || '',
+      'node_group': row['?node_group_str'] || '',
+      'node_label': quoteIfNeeded(row['?node_label_str'] || ''),
+      'node_mapped_to': shortenId(row['?node_mapped_to_str'] || ''),
+      'tissue_label': quoteIfNeeded(row['?tissue_label_str'] || ''),
+      'tissue_mapped_to': shortenId(row['?tissue_mapped_to_str'] || ''),
+      'organ_label': quoteIfNeeded(row['?organ_label_str'] || ''),
+      'organ_mapped_to': shortenId(row['?organ_mapped_to_str'] || '')
+    };
+  });
+
+  // Define the column order based on the query variables
+  const columnHeaders = [
+    'node_id', 'node_group', 'node_label', 'node_mapped_to',
+    'tissue_label', 'tissue_mapped_to', 'organ_label', 'organ_mapped_to'
+  ];
+  
+  // Create CSV content without metadata
+  const csvDataRows = transformedRows.map(row => columnHeaders.map(col => `${row[col] || ''}`).join(','));
+  const outputContent = [
+    columnHeaders.join(','),
+    ...csvDataRows
+  ].join('\n');
+  
+  writeReconstructedData(context, outputContent, 'reconstructed.csv');
+}

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -197,8 +197,37 @@ function transformRecords(context) {
     transformedRows.push(transformedRow);
   });
 
-  // Create sorted column headers
-  const newHeader = Array.from(allColumns).sort();
+  // Create column headers in the specified order: AS, CT, BM, REF
+  const columnOrder = ['AS', 'CT', 'BGene', 'BProtein', 'BLipid', 'BMetabolite', 'BProteoform', 'REF'];
+  
+  const newHeader = Array.from(allColumns).sort((a, b) => {
+    // Get the prefix of each column (e.g., "AS/1" -> "AS", "CT/2/LABEL" -> "CT")
+    const getPrefix = (col) => {
+      const parts = col.split('/');
+      return parts[0];
+    };
+    
+    const prefixA = getPrefix(a);
+    const prefixB = getPrefix(b);
+    
+    // Find the order of each prefix in our desired order
+    const orderA = columnOrder.indexOf(prefixA);
+    const orderB = columnOrder.indexOf(prefixB);
+    
+    // If both prefixes are in our order list, sort by their position
+    if (orderA !== -1 && orderB !== -1) {
+      if (orderA !== orderB) {
+        return orderA - orderB;
+      }
+    }
+    
+    // If only one is in our order list, prioritize it
+    if (orderA !== -1 && orderB === -1) return -1;
+    if (orderA === -1 && orderB !== -1) return 1;
+    
+    // If neither is in our order list or they're the same prefix, sort alphabetically
+    return a.localeCompare(b);
+  });
 
   // Write output
   const outputContent = [newHeader.join(','), ...transformedRows.map(row => newHeader.map(col => row[col] || '').join(','))].join('\n');

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { info, error } from '../utils/logging.js';
-import { writeReconstructedData, executeBlazegraphQuery, loadGraph } from './utils.js';
+import { writeReconstructedData, executeBlazegraphQuery, loadGraph, shortenId } from './utils.js';
 
 export function reconstructAsctb(context) {
   try {   
@@ -92,7 +92,7 @@ function transformRecords(context) {
       const columnPrefix = `AS/${entry.orderNumber}`;
       transformedRow[columnPrefix] = entry.prefLabel;
       transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
-      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      transformedRow[`${columnPrefix}/ID`] = shortenId(entry.sourceConcept);
       
       allColumns.add(columnPrefix);
       allColumns.add(`${columnPrefix}/LABEL`);
@@ -121,7 +121,7 @@ function transformRecords(context) {
       const columnPrefix = `CT/${entry.orderNumber}`;
       transformedRow[columnPrefix] = entry.prefLabel;
       transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
-      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      transformedRow[`${columnPrefix}/ID`] = shortenId(entry.sourceConcept);
       
       allColumns.add(columnPrefix);
       allColumns.add(`${columnPrefix}/LABEL`);
@@ -172,7 +172,7 @@ function transformRecords(context) {
       const columnPrefix = `${bmPrefix}/${entry.orderNumber}`;
       transformedRow[columnPrefix] = entry.prefLabel;
       transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
-      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      transformedRow[`${columnPrefix}/ID`] = shortenId(entry.sourceConcept);
       
       allColumns.add(columnPrefix);
       allColumns.add(`${columnPrefix}/LABEL`);

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -41,7 +41,7 @@ function transformRecords(context) {
   const fileContent = readFileSync(inputFilePath, 'utf8');
 
   // Parse TSV content
-  const lines = fileContent.trim().split('\n');
+  const lines = fileContent.trim().split(/\r?\n/); // Handle both \r\n and \n line endings
   const headers = lines[0].split('\t');
   const dataRows = lines.slice(1).map(line => {
     const values = line.split('\t');

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -232,6 +232,12 @@ function transformRecords(context) {
       allColumns.add(`${columnPrefix}/ID`);
     });
 
+    // Ensure at least one REF column exists
+    if (Object.keys(refEntries).length === 0) {
+      allColumns.add('REF/1');
+      allColumns.add('REF/1/ID');
+    }
+
     transformedRows.push(transformedRow);
   });
 

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -1,11 +1,13 @@
+import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { info, error } from '../utils/logging.js';
-import { executeBlazegraphQuery, loadGraph } from './utils.js';
+import { writeReconstructedData, executeBlazegraphQuery, loadGraph } from './utils.js';
 
 export function reconstructAsctb(context) {
   try {   
     loadGraph(context);
     queryGraph(context);
+    transformRecords(context);
 
     info('ASCT-B reconstruction completed successfully');
   } catch (err) {
@@ -29,4 +31,176 @@ function queryGraph(context) {
     error('Error during graph query:', err);
     throw err;
   }
+}
+
+function transformRecords(context) {
+  const reconstructPath = resolve(context.reconstructionHome);
+  const inputFilePath = resolve(reconstructPath, 'records.tsv');
+
+  info('Reading TSV file...');
+  const fileContent = readFileSync(inputFilePath, 'utf8');
+
+  // Parse TSV content
+  const lines = fileContent.trim().split('\n');
+  const headers = lines[0].split('\t');
+  const dataRows = lines.slice(1).map(line => {
+    const values = line.split('\t');
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || '';
+    });
+    return row;
+  });
+
+  // Group records by record_number_str
+  const recordGroups = {};
+  dataRows.forEach(row => {
+    const recordNumber = row['?record_number_str'];
+    if (!recordGroups[recordNumber]) {
+      recordGroups[recordNumber] = [];
+    }
+    recordGroups[recordNumber].push(row);
+  });
+
+  // Process each record group
+  const transformedRows = [];
+  const allColumns = new Set();
+
+  Object.keys(recordGroups).forEach(recordNumber => {
+    const group = recordGroups[recordNumber];
+    const transformedRow = {};
+
+    // Process anatomical structures (as_)
+    const asEntries = group.reduce((acc, row) => {
+      const asRecordNumber = row['?as_record_number_str'];
+      const asOrderNumber = row['?as_order_number_str'];
+      const key = `${asRecordNumber}-${asOrderNumber}`;
+      
+      if (!acc[key]) {
+        acc[key] = {
+          recordNumber: asRecordNumber,
+          orderNumber: asOrderNumber,
+          prefLabel: row['?as_pref_label_str'],
+          sourceConcept: row['?as_source_concept_str'],
+          conceptLabel: row['?as_concept_label_str']
+        };
+      }
+      return acc;
+    }, {});
+
+    Object.values(asEntries).forEach(entry => {
+      const columnPrefix = `AS/${entry.orderNumber}`;
+      transformedRow[columnPrefix] = entry.prefLabel;
+      transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
+      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      
+      allColumns.add(columnPrefix);
+      allColumns.add(`${columnPrefix}/LABEL`);
+      allColumns.add(`${columnPrefix}/ID`);
+    });
+
+    // Process cell types (ct_)
+    const ctEntries = group.reduce((acc, row) => {
+      const ctRecordNumber = row['?ct_record_number_str'];
+      const ctOrderNumber = row['?ct_order_number_str'];
+      const key = `${ctRecordNumber}-${ctOrderNumber}`;
+      
+      if (!acc[key]) {
+        acc[key] = {
+          recordNumber: ctRecordNumber,
+          orderNumber: ctOrderNumber,
+          prefLabel: row['?ct_pref_label_str'],
+          sourceConcept: row['?ct_source_concept_str'],
+          conceptLabel: row['?ct_concept_label_str']
+        };
+      }
+      return acc;
+    }, {});
+
+    Object.values(ctEntries).forEach(entry => {
+      const columnPrefix = `CT/${entry.orderNumber}`;
+      transformedRow[columnPrefix] = entry.prefLabel;
+      transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
+      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      
+      allColumns.add(columnPrefix);
+      allColumns.add(`${columnPrefix}/LABEL`);
+      allColumns.add(`${columnPrefix}/ID`);
+    });
+
+    // Process biomarkers (bm_)
+    const bmEntries = group.reduce((acc, row) => {
+      const bmRecordNumber = row['?bm_record_number_str'];
+      const bmOrderNumber = row['?bm_order_number_str'];
+      const biomarkerType = row['?bm_biomarker_type_str'];
+      const key = `${bmRecordNumber}-${bmOrderNumber}`;
+      
+      if (!acc[key]) {
+        acc[key] = {
+          recordNumber: bmRecordNumber,
+          orderNumber: bmOrderNumber,
+          biomarkerType: biomarkerType,
+          prefLabel: row['?bm_pref_label_str'],
+          sourceConcept: row['?bm_source_concept_str'],
+          conceptLabel: row['?bm_concept_label_str']
+        };
+      }
+      return acc;
+    }, {});
+
+    Object.values(bmEntries).forEach(entry => {
+      // Map biomarker type to prefix
+      let bmPrefix;
+      switch (entry.biomarkerType) {
+        case 'gene':
+          bmPrefix = 'BGene';
+          break;
+        case 'protein':
+          bmPrefix = 'BProtein';
+          break;
+        case 'lipids':
+          bmPrefix = 'BLipid';
+          break;
+        case 'metabolites':
+          bmPrefix = 'BMetabolite';
+          break;
+        case 'proteoforms':
+          bmPrefix = 'BProteoform';
+          break;
+      }
+
+      const columnPrefix = `${bmPrefix}/${entry.orderNumber}`;
+      transformedRow[columnPrefix] = entry.prefLabel;
+      transformedRow[`${columnPrefix}/LABEL`] = entry.conceptLabel;
+      transformedRow[`${columnPrefix}/ID`] = entry.sourceConcept;
+      
+      allColumns.add(columnPrefix);
+      allColumns.add(`${columnPrefix}/LABEL`);
+      allColumns.add(`${columnPrefix}/ID`);
+    });
+
+    // Process references (record_references_str)
+    const references = group[0]['?record_references_str'];
+    if (references && references.trim()) {
+      const refList = references.split(',').map(ref => ref.trim()).filter(ref => ref);
+      refList.forEach((ref, index) => {
+        const refNumber = index + 1;
+        const columnPrefix = `REF/${refNumber}`;
+        transformedRow[columnPrefix] = ref;
+        transformedRow[`${columnPrefix}/ID`] = ref; // Using the same value for ID as specified
+        
+        allColumns.add(columnPrefix);
+        allColumns.add(`${columnPrefix}/ID`);
+      });
+    }
+
+    transformedRows.push(transformedRow);
+  });
+
+  // Create sorted column headers
+  const newHeader = Array.from(allColumns).sort();
+
+  // Write output
+  const outputContent = [newHeader.join(','), ...transformedRows.map(row => newHeader.map(col => row[col] || '').join(','))].join('\n');
+  writeReconstructedData(context, outputContent, 'reconstructed.csv');
 }

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -1,9 +1,10 @@
 import { resolve } from 'path';
 import { info, error } from '../utils/logging.js';
-import { executeBlazegraphQuery } from './utils.js';
+import { executeBlazegraphQuery, loadGraph } from './utils.js';
 
 export function reconstructAsctb(context) {
   try {   
+    loadGraph(context);
     queryGraph(context);
 
     info('ASCT-B reconstruction completed successfully');

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -1,0 +1,31 @@
+import { resolve } from 'path';
+import { info, error } from '../utils/logging.js';
+import { executeBlazegraphQuery } from './utils.js';
+
+export function reconstructAsctb(context) {
+  try {   
+    queryGraph(context);
+
+    info('ASCT-B reconstruction completed successfully');
+  } catch (err) {
+    error('Error during ASCT-B reconstruction:', err);
+    throw err;
+  }
+}
+
+function queryGraph(context) {
+  try {
+    const processorHome = resolve(context.processorHome);
+    const reconstructPath = resolve(context.reconstructionHome);
+    const journalPath = resolve(reconstructPath, 'blazegraph.jnl');
+    const queryPath = resolve(processorHome, 'src/reconstruction/queries/get-asct-b-records.rq');
+    const outputPath = resolve(reconstructPath, 'records.tsv');
+
+    executeBlazegraphQuery(journalPath, queryPath, outputPath);
+    
+    info('Graph query completed successfully');
+  } catch (err) {
+    error('Error during graph query:', err);
+    throw err;
+  }
+}

--- a/src/reconstruction/reconstruct-asct-b.js
+++ b/src/reconstruction/reconstruct-asct-b.js
@@ -168,6 +168,10 @@ function transformRecords(context) {
     }, {});
 
     Object.values(bmEntries).forEach(entry => {
+      // Skip if biomarkerType is empty
+      if (!entry.biomarkerType) {
+        return;
+      }
       // Map biomarker type to prefix
       let bmPrefix;
       switch (entry.biomarkerType) {

--- a/src/reconstruction/reconstruct-collection.js
+++ b/src/reconstruction/reconstruct-collection.js
@@ -1,0 +1,89 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { info, error } from '../utils/logging.js';
+import { writeReconstructedData, executeBlazegraphQuery, loadGraph } from './utils.js';
+
+export function reconstructCollection(context) {
+  try {   
+    loadGraph(context);
+    queryGraph(context);
+    transformRecords(context);
+
+    info('Collection reconstruction completed successfully');
+  } catch (err) {
+    error('Error during Collection reconstruction:', err);
+    throw err;
+  }
+}
+
+function queryGraph(context) {
+  try {
+    const processorHome = resolve(context.processorHome);
+    const reconstructPath = resolve(context.reconstructionHome);
+    const journalPath = resolve(reconstructPath, 'blazegraph.jnl');
+
+    // Query records only (no metadata)
+    const recordsQueryPath = resolve(processorHome, 'src/reconstruction/queries/get-collection-records.rq');
+    const recordsOutputPath = resolve(reconstructPath, 'records.tsv');
+    executeBlazegraphQuery(journalPath, recordsQueryPath, recordsOutputPath);
+
+    info('Graph query completed successfully');
+  } catch (err) {
+    error('Error during graph query:', err);
+    throw err;
+  }
+}
+
+function transformRecords(context) {
+  const reconstructPath = resolve(context.reconstructionHome);
+  const inputFilePath = resolve(reconstructPath, 'records.tsv');
+
+  info('Reading TSV file...');
+  const fileContent = readFileSync(inputFilePath, 'utf8');
+
+  // Parse TSV content
+  const lines = fileContent.trim().split(/\r?\n/);
+  const headers = lines[0].split('\t');
+  const dataRows = lines.slice(1).map(line => {
+    const values = line.split('\t');
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || '';
+    });
+    return row;
+  });
+
+  // Transform sub_graph URLs to abbreviated format
+  const digitalObjects = dataRows.map(row => {
+    const subGraphStr = row['?sub_graph_str'] || '';
+    return abbreviateSubGraph(subGraphStr);
+  }).filter(item => item !== '') // Remove empty items
+    .sort(); // Sort alphabetically
+
+  // Create YAML output
+  const yamlContent = `digital-objects:\n${digitalObjects.map(item => `  - ${item}`).join('\n')}`;
+  
+  writeReconstructedData(context, yamlContent, 'reconstructed.yaml');
+}
+
+function abbreviateSubGraph(subGraphStr) {
+  // Extract the meaningful part from the sub_graph URL
+  
+  if (!subGraphStr) return '';
+  
+  // Look for patterns that match the expected output format
+  // This assumes the URL contains the relevant path information
+  const match = subGraphStr.match(/([^\/]+\/[^\/]+\/v\d+\.\d+)$/);
+  if (match) {
+    return match[1];
+  }
+  
+  // Fallback: extract last meaningful segments if the pattern doesn't match exactly
+  const segments = subGraphStr.split('/').filter(seg => seg && seg !== 'http:' && seg !== 'https:');
+  if (segments.length >= 3) {
+    // Take the last 3 segments which should be type/name/version
+    return segments.slice(-3).join('/');
+  }
+  
+  return subGraphStr;
+}

--- a/src/reconstruction/reconstruct-omap.js
+++ b/src/reconstruction/reconstruct-omap.js
@@ -1,0 +1,194 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { info, error } from '../utils/logging.js';
+import { writeReconstructedData, executeBlazegraphQuery, loadGraph, shortenId } from './utils.js';
+
+export function reconstructOmap(context) {
+  try {   
+    // loadGraph(context);
+    queryGraph(context);
+    transformRecords(context);
+
+    info('OMAP reconstruction completed successfully');
+  } catch (err) {
+    error('Error during OMAP reconstruction:', err);
+    throw err;
+  }
+}
+
+function queryGraph(context) {
+  try {
+    const processorHome = resolve(context.processorHome);
+    const reconstructPath = resolve(context.reconstructionHome);
+    const journalPath = resolve(reconstructPath, 'blazegraph.jnl');
+
+    // Query records
+    const recordsQueryPath = resolve(processorHome, 'src/reconstruction/queries/get-omap-records.rq');
+    const recordsOutputPath = resolve(reconstructPath, 'records.tsv');
+    executeBlazegraphQuery(journalPath, recordsQueryPath, recordsOutputPath);
+    
+    // Query metadata
+    const metadataQueryPath = resolve(processorHome, 'src/reconstruction/queries/get-omap-metadata.rq');
+    const metadataOutputPath = resolve(reconstructPath, 'metadata.tsv');
+    executeBlazegraphQuery(journalPath, metadataQueryPath, metadataOutputPath);
+
+    info('Graph query completed successfully');
+  } catch (err) {
+    error('Error during graph query:', err);
+    throw err;
+  }
+}
+
+function transformRecords(context) {
+  const reconstructPath = resolve(context.reconstructionHome);
+  const inputFilePath = resolve(reconstructPath, 'records.tsv');
+  const metadataFilePath = resolve(reconstructPath, 'metadata.tsv');
+
+  info('Reading TSV file...');
+  const fileContent = readFileSync(inputFilePath, 'utf8');
+
+  // Read and parse metadata
+  info('Reading metadata file...');
+  const metadataContent = readFileSync(metadataFilePath, 'utf8');
+  const metadataLines = metadataContent.trim().split(/\r?\n/);
+  const metadataHeaders = metadataLines[0].split('\t');
+  const metadataData = metadataLines[1].split('\t');
+  
+  const metadata = {};
+  metadataHeaders.forEach((header, index) => {
+    metadata[header] = metadataData[index] || '';
+  });
+
+  // Parse TSV content
+  const lines = fileContent.trim().split(/\r?\n/); // Handle both \r\n and \n line endings
+  const headers = lines[0].split('\t');
+  const dataRows = lines.slice(1).map(line => {
+    const values = line.split('\t');
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = values[index] || '';
+    });
+    return row;
+  });
+
+  // Group records by record_number_str
+  const recordGroups = {};
+  dataRows.forEach(row => {
+    const recordNumber = row['?record_number_str'];
+    if (!recordGroups[recordNumber]) {
+      recordGroups[recordNumber] = [];
+    }
+    recordGroups[recordNumber].push(row);
+  });
+
+  // Process each record group
+  const transformedRows = [];
+  const allColumns = new Set();
+
+  Object.keys(recordGroups).forEach(recordNumber => {
+    const group = recordGroups[recordNumber];
+    
+    // Process each row in the group (each antibody record)
+    group.forEach(row => {
+      const transformedRow = {};
+      
+      // Extract OMAP ID from experiment id
+      const experimentIri = row['?experiment_str'] || '';
+      const omapId = experimentIri.includes('#') ? experimentIri.split('#').pop() : experimentIri;
+      transformedRow['omap_id'] = omapId;
+      
+      // Extract protein information - need to parse from detected_protein_id_str
+      const detectedProteinId = row['?detected_protein_id_str'] || '';
+      transformedRow['uniprot_accession_number'] = row['?uniprot_id_str'] || '';
+      transformedRow['HGNC_ID'] = row['?detected_protein_id_str']?.replace('http://identifiers.org/hgnc/', 'HGNC:') || '';
+      transformedRow['target_symbol'] = row['?detected_protein_label_str'] || '';
+      // Antibody host information
+      transformedRow['host'] = row['?host_str'] || '';
+      transformedRow['isotype'] = row['?isotype_str'] || '';
+      transformedRow['clonality'] = row['?clonality_str'] || '';
+      transformedRow['clone_id'] = row['?clone_id_str'] || '';
+      
+      // Vendor information
+      transformedRow['vendor'] = row['?antibody_manufacturer_str'] || '';
+      transformedRow['catalog_number'] = row['?catalog_number_str'] || '';
+      transformedRow['lot_number'] = row['?lot_number_str'] || '';
+      
+      // Recombinant status
+      transformedRow['recombinant'] = row['?recombinant_str'] || '';
+      
+      // Concentration and dilution
+      transformedRow['concentration_value'] = row['?concentration_str'] || '';
+      transformedRow['dilution_factor'] = row['?dilution_str'] || '';
+      
+      // Conjugate information - need to determine from fluorescent reporter
+      transformedRow['conjugate'] = row['?conjugate_str'] || '';
+      
+      // RRID from registered antibody
+      const rrid = row['?antibody_str'] || '';
+      transformedRow['rrid'] = rrid.replace('https://identifiers.org/RRID:', '') || '';
+      
+      // Method and preservation
+      transformedRow['method'] = row['?study_method_str'] || '';
+      transformedRow['tissue_preservation'] = row['?tissue_preservation_str'] || '';
+      
+      // Cycle information
+      transformedRow['cycle_number'] = row['?cycle_number_str'] || '';
+      transformedRow['fluorescent_reporter'] = '';
+      
+      // Protocol DOI
+      transformedRow['protocol_doi'] = row['?protocol_doi_str'] || '';
+      
+      // Author ORCIDs - clean up the format
+      const authorOrcids = row['?author_orcid_str'] || '';
+      transformedRow['author_orcids'] = authorOrcids.replace(/http:\/\/purl\.org\/ccf\//g, '').replace(/,\s*/g, ', ');
+      
+      // Core panel status
+      transformedRow['core_panel'] = row['?is_core_panel_str'] === 'true' ? 'Y' : 'N';
+      
+      // Rationale
+      transformedRow['rationale'] = row['?rationale_str'] || '';
+      
+      // Organ information
+      transformedRow['organ'] = row['?sample_organ_label_str'] || '';
+      transformedRow['organ_uberon'] = row['?sample_organ_str']?.replace('http://purl.obolibrary.org/obo/UBERON_', 'UBERON:') || '';
+      
+      transformedRows.push(transformedRow);
+      
+      // Track all columns
+      Object.keys(transformedRow).forEach(key => allColumns.add(key));
+    });
+  });
+
+  // Define the column order based on the target OMAP CSV structure
+  const newHeader = [
+    'omap_id', 'uniprot_accession_number', 'HGNC_ID', 'target_symbol',
+    'host', 'isotype', 'clonality', 'clone_id', 'vendor', 'catalog_number', 'lot_number',
+    'recombinant', 'concentration_value', 'dilution_factor', 'conjugate', 'rrid',
+    'method', 'tissue_preservation', 'cycle_number', 'fluorescent_reporter', 'protocol_doi',
+    'author_orcids', 'core_panel', 'rationale', 'organ', 'organ_uberon'
+  ];
+  
+  // Create metadata rows
+  const metadataRows = [
+    [metadata['?tableTitle'], '', '', '', '', '', '', '', ''], // First row with table title
+    ['', '', '', '', '', '', '', '', ''], // Empty second row
+    [`Author Name(s):`, metadata['?authorNames']],
+    [`Author ORCID(s):`, metadata['?authorOrcids']],
+    [`Reviewer(s):`, metadata['?reviewerNames']],
+    [`Reviewer ORCID(s):`, metadata['?reviewerOrcids']],
+    [`General Publication(s):`, metadata['?generalPublications']],
+    [`Data DOI:`, metadata['?dataDoi']],
+    [`Date:`, metadata['?date']],
+    [`Version Number:`, metadata['?versionNumber']]
+  ];
+
+  // Write output with metadata at the top
+  const csvDataRows = transformedRows.map(row => newHeader.map(col => `"${row[col] || ''}"`).join(','));
+  const outputContent = [
+    ...metadataRows.map(row => row.map(cell => `"${cell}"`).join(',')),
+    newHeader.map(col => `"${col}"`).join(','),
+    ...csvDataRows
+  ].join('\n');
+  
+  writeReconstructedData(context, outputContent, 'reconstructed.csv');
+}

--- a/src/reconstruction/reconstruct-omap.js
+++ b/src/reconstruction/reconstruct-omap.js
@@ -5,7 +5,7 @@ import { writeReconstructedData, executeBlazegraphQuery, loadGraph, shortenId } 
 
 export function reconstructOmap(context) {
   try {   
-    // loadGraph(context);
+    loadGraph(context);
     queryGraph(context);
     transformRecords(context);
 

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -1,11 +1,12 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { header, warning, error } from '../utils/logging.js';
+import { header, error } from '../utils/logging.js';
 import { reconstructAsctb } from './reconstruct-asct-b.js';
 import { reconstructOmap } from './reconstruct-omap.js';
 import { reconstructCtann } from './reconstruct-ctann.js';
 import { reconstructRefOrgan } from './reconstruct-ref-organ.js';
 import { reconstruct2dFtu } from './reconstruct-2d-ftu.js';
+import { reconstructCollection } from './reconstruct-collection.js';
 import { cleanDirectory } from './utils.js';
 
 export function reconstruct(context) {
@@ -33,7 +34,7 @@ export function reconstruct(context) {
       reconstruct2dFtu(context);
       break;
     case 'collection':
-      warning(`"${obj.type}" digital object type is not yet implemented.`);
+      reconstructCollection(context);
       break;
     default:
       error(`"${obj.type}" digital object type is not supported for reconstruction.`);

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -1,8 +1,9 @@
 import { resolve } from 'path';
 import sh from 'shelljs';
-import { header, warning } from '../utils/logging.js';
+import { header, warning, error } from '../utils/logging.js';
 import { reconstructAsctb } from './reconstruct-asct-b.js';
 import { reconstructOmap } from './reconstruct-omap.js';
+import { reconstructCtann } from './reconstruct-ctann.js';
 import { cleanDirectory } from './utils.js';
 
 export function reconstruct(context) {
@@ -21,6 +22,8 @@ export function reconstruct(context) {
       reconstructOmap(context);
       break;
     case 'ctann':
+      reconstructCtann(context);
+      break;
     case 'ref-organ':
     case '2d-ftu':
     case 'collection':

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -4,6 +4,7 @@ import { header, warning, error } from '../utils/logging.js';
 import { reconstructAsctb } from './reconstruct-asct-b.js';
 import { reconstructOmap } from './reconstruct-omap.js';
 import { reconstructCtann } from './reconstruct-ctann.js';
+import { reconstructRefOrgan } from './reconstruct-ref-organ.js';
 import { cleanDirectory } from './utils.js';
 
 export function reconstruct(context) {
@@ -25,6 +26,8 @@ export function reconstruct(context) {
       reconstructCtann(context);
       break;
     case 'ref-organ':
+      reconstructRefOrgan(context);
+      break;
     case '2d-ftu':
     case 'collection':
       warning(`"${obj.type}" digital object type is not yet implemented.`);

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -5,6 +5,7 @@ import { reconstructAsctb } from './reconstruct-asct-b.js';
 import { reconstructOmap } from './reconstruct-omap.js';
 import { reconstructCtann } from './reconstruct-ctann.js';
 import { reconstructRefOrgan } from './reconstruct-ref-organ.js';
+import { reconstruct2dFtu } from './reconstruct-2d-ftu.js';
 import { cleanDirectory } from './utils.js';
 
 export function reconstruct(context) {
@@ -29,6 +30,8 @@ export function reconstruct(context) {
       reconstructRefOrgan(context);
       break;
     case '2d-ftu':
+      reconstruct2dFtu(context);
+      break;
     case 'collection':
       warning(`"${obj.type}" digital object type is not yet implemented.`);
       break;

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -2,6 +2,7 @@ import { resolve } from 'path';
 import sh from 'shelljs';
 import { header, warning } from '../utils/logging.js';
 import { reconstructAsctb } from './reconstruct-asct-b.js';
+import { reconstructOmap } from './reconstruct-omap.js';
 import { cleanDirectory } from './utils.js';
 
 export function reconstruct(context) {
@@ -17,6 +18,8 @@ export function reconstruct(context) {
       reconstructAsctb(context);
       break;
     case 'omap':
+      reconstructOmap(context);
+      break;
     case 'ctann':
     case 'ref-organ':
     case '2d-ftu':

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -1,3 +1,38 @@
-export function reconstruct(context) {
+import { existsSync, mkdirSync, rmSync } from 'fs';
+import { resolve } from 'path';
+import sh from 'shelljs';
+import { info } from '../utils/logging.js';
+import { reifyDoTurtle, reifyMetadataTurtle, reifyRedundantTurtle } from '../utils/reify.js';
+import { loadDoIntoTripleStore, loadRedundantIntoTripleStore } from '../deployment/utils.js';
 
+export function reconstruct(context) {
+  const obj = context.selectedDigitalObject;
+  const reconstructPath = resolve(context.reconstructionHome);
+  const graphTtl = resolve(reconstructPath, 'graph.ttl');
+  const metadataTtl = resolve(reconstructPath, 'metadata.ttl');
+
+  // Remove existing reconstruct path if it exists, then create fresh
+  if (existsSync(reconstructPath)) {
+    rmSync(reconstructPath, { recursive: true, force: true });
+  }
+  mkdirSync(reconstructPath, { recursive: true });
+
+  sh.cp(resolve(obj.path, 'enriched/enriched.ttl'), graphTtl);
+  sh.cp(resolve(obj.path, 'enriched/enriched-metadata.ttl'), metadataTtl);
+
+  info(`Reifying "${obj.doString}"`);
+  reifyDoTurtle(context, graphTtl);
+  loadDoIntoTripleStore(context, resolve(context.reconstructionHome, 'blazegraph.jnl'));
+
+  info(`Reifying "${obj.doString}" metadata`);
+  reifyMetadataTurtle(context, metadataTtl);
+
+  // Check if the enrichment produces redundant graph
+  const redundant = resolve(obj.path, 'enriched/redundant.ttl');
+  if (existsSync(redundant)) {
+    const redundantReconstructPath = resolve(reconstructPath, 'redundant.ttl');
+    sh.cp(redundant, redundantReconstructPath);
+    reifyRedundantTurtle(context, redundantReconstructPath);
+    loadRedundantIntoTripleStore(context, resolve(context.reconstructionHome, 'blazegraph.jnl'));
+  }
 }

--- a/src/reconstruction/reconstruct.js
+++ b/src/reconstruction/reconstruct.js
@@ -1,0 +1,3 @@
+export function reconstruct(context) {
+
+}

--- a/src/reconstruction/utils.js
+++ b/src/reconstruction/utils.js
@@ -6,6 +6,32 @@ import { info } from '../utils/logging.js';
 import { reifyDoTurtle, reifyMetadataTurtle, reifyRedundantTurtle } from '../utils/reify.js';
 import { loadDoIntoTripleStore, loadRedundantIntoTripleStore } from '../deployment/utils.js';
 
+// Prefix definitions for shortening URIs
+const PREFIX_MAPPINGS = {
+  'http://purl.obolibrary.org/obo/UBERON_': 'UBERON:',
+  'http://purl.obolibrary.org/obo/CL_': 'CL:',
+  'http://purl.obolibrary.org/obo/PCL_': 'PCL:',
+  'http://purl.obolibrary.org/obo/LMHA_': 'LMHA:',
+  'http://purl.org/sig/ont/fma/fma': 'FMA:',
+  'http://identifiers.org/hgnc/': 'HGNC:'
+};
+
+export function shortenId(uri) {
+  if (!uri || typeof uri !== 'string') {
+    return uri;
+  }
+
+  // Check each prefix mapping
+  for (const [fullPrefix, shortPrefix] of Object.entries(PREFIX_MAPPINGS)) {
+    if (uri.startsWith(fullPrefix)) {
+      return uri.replace(fullPrefix, shortPrefix);
+    }
+  }
+
+  // Return original URI if no prefix matches
+  return uri;
+}
+
 export function loadGraph(context) {
   const obj = context.selectedDigitalObject;
   const reconstructPath = resolve(context.reconstructionHome);

--- a/src/reconstruction/utils.js
+++ b/src/reconstruction/utils.js
@@ -1,0 +1,60 @@
+import sh from 'shelljs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { throwOnError } from '../utils/sh-exec.js';
+import { info } from '../utils/logging.js';
+import { reifyDoTurtle, reifyMetadataTurtle, reifyRedundantTurtle } from '../utils/reify.js';
+import { loadDoIntoTripleStore, loadRedundantIntoTripleStore } from '../deployment/utils.js';
+
+export function loadGraph(context) {
+  const obj = context.selectedDigitalObject;
+  const reconstructPath = resolve(context.reconstructionHome);
+  const graphTtl = resolve(reconstructPath, 'graph.ttl');
+  const metadataTtl = resolve(reconstructPath, 'metadata.ttl');
+
+  // Remove existing reconstruct path if it exists, then create fresh
+  if (existsSync(reconstructPath)) {
+    rmSync(reconstructPath, { recursive: true, force: true });
+  }
+  mkdirSync(reconstructPath, { recursive: true });
+
+  sh.cp(resolve(obj.path, 'enriched/enriched.ttl'), graphTtl);
+  sh.cp(resolve(obj.path, 'enriched/enriched-metadata.ttl'), metadataTtl);
+
+  info(`Reifying "${obj.doString}"`);
+  reifyDoTurtle(context, graphTtl);
+  loadDoIntoTripleStore(context, resolve(context.reconstructionHome, 'blazegraph.jnl'));
+
+  info(`Reifying "${obj.doString}" metadata`);
+  reifyMetadataTurtle(context, metadataTtl);
+
+  // Check if the enrichment produces redundant graph
+  const redundant = resolve(obj.path, 'enriched/redundant.ttl');
+  if (existsSync(redundant)) {
+    const redundantReconstructPath = resolve(reconstructPath, 'redundant.ttl');
+    sh.cp(redundant, redundantReconstructPath);
+    reifyRedundantTurtle(context, redundantReconstructPath);
+    loadRedundantIntoTripleStore(context, resolve(context.reconstructionHome, 'blazegraph.jnl'));
+  }
+}
+
+export function executeBlazegraphQuery(journalPath, queryPath, outputPath) {
+  const command = `blazegraph-runner select --journal=${journalPath} --outformat=tsv ${queryPath} ${outputPath}`;
+  throwOnError(command, 'Error executing blazegraph query');
+}
+
+export function writeReconstructedData(context, data, outputFile) {
+  const { path } = context.selectedDigitalObject;
+  const reconstructedPath = resolve(path, 'reconstructed/', outputFile);
+  writeFileSync(reconstructedPath, data, 'utf8');
+  info(`Reconstructed digital object written to ${reconstructedPath}`);
+}
+
+export function cleanDirectory(context) {
+  const { selectedDigitalObject: obj } = context;
+  const path = resolve(obj.path, 'reconstructed/');
+  throwOnError(
+    `find ${path} -type f -exec rm -f {} +`,
+    'Clean normalized directory failed.'
+  );
+}

--- a/src/reconstruction/utils.js
+++ b/src/reconstruction/utils.js
@@ -85,3 +85,36 @@ export function cleanDirectory(context) {
     'Clean normalized directory failed.'
   );
 }
+
+// Format date from YYYY-MM-DD to quoted "Month DD, YYYY"
+export function formatToMonthDDYYYY(dateStr) {
+  if (!dateStr || dateStr === '') return '';
+  try {
+    // Parse date string directly to avoid timezone issues
+    const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (match) {
+      const [, year, month, day] = match;
+      const monthNames = [
+        'January', 'February', 'March', 'April', 'May', 'June',
+        'July', 'August', 'September', 'October', 'November', 'December'
+      ];
+      const monthName = monthNames[parseInt(month, 10) - 1];
+      return `"${monthName} ${parseInt(day, 10)}, ${year}"`;
+    }
+    return `"${dateStr}"`;
+  } catch (e) {
+    return `"${dateStr}"`;
+  }
+}
+
+// Quote CSV field if it contains commas, quotes, or newlines
+export function quoteIfNeeded(str) {
+  if (!str) return str;
+  // Quote if contains comma, double quote, or newline
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    // Escape any existing double quotes by doubling them
+    const escaped = str.replace(/"/g, '""');
+    return `"${escaped}"`;
+  }
+  return str;
+}

--- a/src/reconstruction/utils.js
+++ b/src/reconstruction/utils.js
@@ -4,7 +4,7 @@ import { resolve } from 'path';
 import { throwOnError } from '../utils/sh-exec.js';
 import { info } from '../utils/logging.js';
 import { reifyDoTurtle, reifyMetadataTurtle, reifyRedundantTurtle } from '../utils/reify.js';
-import { loadDoIntoTripleStore, loadRedundantIntoTripleStore } from '../deployment/utils.js';
+import { loadDoIntoTripleStore, loadMetadataIntoTripleStore, loadRedundantIntoTripleStore } from '../deployment/utils.js';
 
 // Prefix definitions for shortening URIs
 const PREFIX_MAPPINGS = {
@@ -53,6 +53,7 @@ export function loadGraph(context) {
 
   info(`Reifying "${obj.doString}" metadata`);
   reifyMetadataTurtle(context, metadataTtl);
+  loadMetadataIntoTripleStore(context, resolve(context.reconstructionHome, 'blazegraph.jnl'));
 
   // Check if the enrichment produces redundant graph
   const redundant = resolve(obj.path, 'enriched/redundant.ttl');

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -10,6 +10,7 @@ const DEFAULT_CDN_IRI = process.env.DEFAULT_CDN_IRI || 'https://cdn.humanatlas.i
 
 const DEFAULT_DO_HOME = resolve(process.env.DO_HOME || './digital-objects');
 const DEFAULT_DEPLOY_HOME = resolve(process.env.DEPLOY_HOME || './dist');
+const DEFAULT_RECONSTRUCT_HOME = resolve(process.env.RECONSTRUCT_HOME || './.store');
 export const PROCESSOR_HOME = resolve(process.env.PROCESSOR_HOME || dirname(dirname(getDirName(import.meta.url))));
 
 export function getProcessorVersion() {
@@ -22,6 +23,7 @@ export function getContext(program, subcommand, selectedDigitalObject) {
     doHome: DEFAULT_DO_HOME,
     processorHome: PROCESSOR_HOME,
     deploymentHome: DEFAULT_DEPLOY_HOME,
+    reconstructionHome: DEFAULT_RECONSTRUCT_HOME,
     purlIri: DEFAULT_PURL_IRI,
     lodIri: DEFAULT_LOD_IRI,
     cdnIri: DEFAULT_CDN_IRI,


### PR DESCRIPTION
This subcommand is used to reproduce the original source data that was used during the knowledge graph construction. It does this by querying the knowledge graph itself, extracting the relevant information, and then reorganizing or reformatting the data so that it closely resembles the original tabular format from which it was derived.